### PR TITLE
Implement SVO format, converter, and rendering

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "external/glm"]
 	path = external/glm
 	url = https://github.com/g-truc/glm.git
+[submodule "external/libmorton"]
+	path = external/libmorton
+	url = https://github.com/Forceflow/libmorton.git

--- a/drivers/ivs.cpp
+++ b/drivers/ivs.cpp
@@ -9,17 +9,17 @@ int main(int argc, char *argv[]) {
     auto test_sphere_data2 = generate_basic_sphere_chunk(64, 64, 64, 20);
     auto test_proc_data1 = generate_basic_procedural_chunk(16, 16, 16);
     // auto test_load = load_vox_scene_as_models("models/3x3x3.vox");
-    auto test_svo_data1 = convert_raw_to_svo(test_proc_data1, 16, 16, 16, 4);
+    auto test_svo_data1 = convert_raw_to_svo(test_sphere_data1, 64, 64, 64, 4);
     debug_print_svo(test_svo_data1, 4);
 
     VoxelChunkPtr test_sphere1 = chunk_manager.add_chunk(
-        std::move(test_sphere_data1), 64, 64, 64, VoxelChunk::Format::Raw,
+        std::move(test_svo_data1), 64, 64, 64, VoxelChunk::Format::SVO,
         VoxelChunk::AttributeSet::Color);
     VoxelChunkPtr test_sphere2 = chunk_manager.add_chunk(
         std::move(test_sphere_data2), 64, 64, 64, VoxelChunk::Format::Raw,
         VoxelChunk::AttributeSet::Color);
     VoxelChunkPtr test_proc1 = chunk_manager.add_chunk(
-        std::move(test_svo_data1), 16, 16, 16, VoxelChunk::Format::SVO,
+        std::move(test_proc_data1), 16, 16, 16, VoxelChunk::Format::Raw,
         VoxelChunk::AttributeSet::Color);
 
     auto context = create_graphics_context();

--- a/drivers/ivs.cpp
+++ b/drivers/ivs.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[]) {
                               sinf(4.0F), cosf(4.0F),  0.0F, 1.0F,
                               0.0F,       0.0F,        1.0F, 0.0F};
     glm::mat3x4 transform4 = {4.0F, 0.0F, 0.0F, -6.0F, 0.0F, 4.0F,
-                              0.0F, 0.0F, 0.0F, 0.0F,  4.0F, -6.0F};
+                              0.0F, -3.0F, 0.0F, 0.0F,  4.0F, -6.0F};
     auto object1 = build_object(context, model1, transform1);
     auto object2 = build_object(context, model2, transform2);
     auto object3 = build_object(context, model2, transform3);

--- a/drivers/ivs.cpp
+++ b/drivers/ivs.cpp
@@ -1,7 +1,7 @@
 #include <graphics/GraphicsContext.h>
+#include <voxels/Conversion.h>
 #include <voxels/Voxel.h>
 #include <voxels/VoxelChunkGeneration.h>
-#include <voxels/Conversion.h>
 
 int main(int argc, char *argv[]) {
     ChunkManager chunk_manager;
@@ -19,7 +19,7 @@ int main(int argc, char *argv[]) {
         std::move(test_sphere_data2), 64, 64, 64, VoxelChunk::Format::Raw,
         VoxelChunk::AttributeSet::Color);
     VoxelChunkPtr test_proc1 = chunk_manager.add_chunk(
-        std::move(test_proc_data1), 16, 16, 16, VoxelChunk::Format::Raw,
+        std::move(test_svo_data1), 16, 16, 16, VoxelChunk::Format::SVO,
         VoxelChunk::AttributeSet::Color);
 
     auto context = create_graphics_context();

--- a/drivers/ivs.cpp
+++ b/drivers/ivs.cpp
@@ -34,13 +34,13 @@ int main(int argc, char *argv[]) {
     glm::mat3x4 transform3 = {cosf(4.0F), -sinf(4.0F), 0.0F, 0.0F,
                               sinf(4.0F), cosf(4.0F),  0.0F, 1.0F,
                               0.0F,       0.0F,        1.0F, 0.0F};
-    glm::mat3x4 transform4 = {4.0F, 0.0F, 0.0F, -6.0F, 0.0F, 4.0F,
-                              0.0F, -3.0F, 0.0F, 0.0F,  4.0F, -6.0F};
-    auto object1 = build_object(context, model1, transform1);
-    auto object2 = build_object(context, model2, transform2);
-    auto object3 = build_object(context, model2, transform3);
+    glm::mat3x4 transform4 = {1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F,
+                              0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F};
+    //auto object1 = build_object(context, model1, transform1);
+    //auto object2 = build_object(context, model2, transform2);
+    //auto object3 = build_object(context, model2, transform3);
     auto object4 = build_object(context, model3, transform4);
-    auto scene = build_scene(context, {object1, object2, object3, object4});
+    auto scene = build_scene(context, {object4});
 
     while (!should_exit(context)) {
         render_frame(context, scene);

--- a/drivers/ivs.cpp
+++ b/drivers/ivs.cpp
@@ -1,7 +1,7 @@
 #include <graphics/GraphicsContext.h>
-#include <voxels/Conversion.h>
 #include <voxels/Voxel.h>
 #include <voxels/VoxelChunkGeneration.h>
+#include <voxels/Conversion.h>
 
 int main(int argc, char *argv[]) {
     ChunkManager chunk_manager;
@@ -34,13 +34,13 @@ int main(int argc, char *argv[]) {
     glm::mat3x4 transform3 = {cosf(4.0F), -sinf(4.0F), 0.0F, 0.0F,
                               sinf(4.0F), cosf(4.0F),  0.0F, 1.0F,
                               0.0F,       0.0F,        1.0F, 0.0F};
-    glm::mat3x4 transform4 = {1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F,
-                              0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F};
-    //auto object1 = build_object(context, model1, transform1);
-    //auto object2 = build_object(context, model2, transform2);
-    //auto object3 = build_object(context, model2, transform3);
+    glm::mat3x4 transform4 = {4.0F, 0.0F, 0.0F, -5.0F, 0.0F, 4.0F,
+                              0.0F, 0.0F, 0.0F, 0.0F,  4.0F, -5.0F};
+    auto object1 = build_object(context, model1, transform1);
+    auto object2 = build_object(context, model2, transform2);
+    auto object3 = build_object(context, model2, transform3);
     auto object4 = build_object(context, model3, transform4);
-    auto scene = build_scene(context, {object4});
+    auto scene = build_scene(context, {object1, object2, object3, object4});
 
     while (!should_exit(context)) {
         render_frame(context, scene);

--- a/drivers/ivs.cpp
+++ b/drivers/ivs.cpp
@@ -1,7 +1,7 @@
 #include <graphics/GraphicsContext.h>
+#include <voxels/Conversion.h>
 #include <voxels/Voxel.h>
 #include <voxels/VoxelChunkGeneration.h>
-#include <voxels/Conversion.h>
 
 int main(int argc, char *argv[]) {
     ChunkManager chunk_manager;
@@ -9,18 +9,16 @@ int main(int argc, char *argv[]) {
     auto test_sphere_data2 = generate_basic_sphere_chunk(64, 64, 64, 20);
     auto test_proc_data1 = generate_basic_procedural_chunk(16, 16, 16);
     // auto test_load = load_vox_scene_as_models("models/3x3x3.vox");
-    auto test_svo_data1 = convert_raw_to_svo(test_sphere_data1, 64, 64, 64, 4);
-    debug_print_svo(test_svo_data1, 4);
 
     VoxelChunkPtr test_sphere1 = chunk_manager.add_chunk(
-        std::move(test_svo_data1), 64, 64, 64, VoxelChunk::Format::SVO,
-        VoxelChunk::AttributeSet::Color);
+        convert_raw_to_svo(std::move(test_sphere_data1), 64, 64, 64, 4), 64, 64,
+        64, VoxelChunk::Format::SVO, VoxelChunk::AttributeSet::Color);
     VoxelChunkPtr test_sphere2 = chunk_manager.add_chunk(
-        std::move(test_sphere_data2), 64, 64, 64, VoxelChunk::Format::Raw,
-        VoxelChunk::AttributeSet::Color);
+        convert_raw_to_svo(std::move(test_sphere_data2), 64, 64, 64, 4), 64, 64,
+        64, VoxelChunk::Format::SVO, VoxelChunk::AttributeSet::Color);
     VoxelChunkPtr test_proc1 = chunk_manager.add_chunk(
-        std::move(test_proc_data1), 16, 16, 16, VoxelChunk::Format::Raw,
-        VoxelChunk::AttributeSet::Color);
+        convert_raw_to_svo(std::move(test_proc_data1), 16, 16, 16, 4), 16, 16,
+        16, VoxelChunk::Format::SVO, VoxelChunk::AttributeSet::Color);
 
     auto context = create_graphics_context();
 

--- a/drivers/ivs.cpp
+++ b/drivers/ivs.cpp
@@ -1,6 +1,7 @@
 #include <graphics/GraphicsContext.h>
 #include <voxels/Voxel.h>
 #include <voxels/VoxelChunkGeneration.h>
+#include <voxels/Conversion.h>
 
 int main(int argc, char *argv[]) {
     ChunkManager chunk_manager;
@@ -8,6 +9,8 @@ int main(int argc, char *argv[]) {
     auto test_sphere_data2 = generate_basic_sphere_chunk(64, 64, 64, 20);
     auto test_proc_data1 = generate_basic_procedural_chunk(16, 16, 16);
     // auto test_load = load_vox_scene_as_models("models/3x3x3.vox");
+    auto test_svo_data1 = convert_raw_to_svo(test_proc_data1, 16, 16, 16, 4);
+    debug_print_svo(test_svo_data1, 4);
 
     VoxelChunkPtr test_sphere1 = chunk_manager.add_chunk(
         std::move(test_sphere_data1), 64, 64, 64, VoxelChunk::Format::Raw,

--- a/drivers/ivs.cpp
+++ b/drivers/ivs.cpp
@@ -34,8 +34,8 @@ int main(int argc, char *argv[]) {
     glm::mat3x4 transform3 = {cosf(4.0F), -sinf(4.0F), 0.0F, 0.0F,
                               sinf(4.0F), cosf(4.0F),  0.0F, 1.0F,
                               0.0F,       0.0F,        1.0F, 0.0F};
-    glm::mat3x4 transform4 = {4.0F, 0.0F, 0.0F, -5.0F, 0.0F, 4.0F,
-                              0.0F, 0.0F, 0.0F, 0.0F,  4.0F, -5.0F};
+    glm::mat3x4 transform4 = {4.0F, 0.0F, 0.0F, -6.0F, 0.0F, 4.0F,
+                              0.0F, 0.0F, 0.0F, 0.0F,  4.0F, -6.0F};
     auto object1 = build_object(context, model1, transform1);
     auto object2 = build_object(context, model2, transform2);
     auto object3 = build_object(context, model2, transform3);

--- a/graphics/Descriptor.cpp
+++ b/graphics/Descriptor.cpp
@@ -255,9 +255,10 @@ DescriptorSetBuilder &DescriptorSetBuilder::bind_buffers(
         write.pNext = nullptr;
         write.descriptorCount = 1;
         write.descriptorType = type;
-        write.pBufferInfo = buffer_infos.empty() ? nullptr
-                                               : &buffer_infos_.back() -
-                                                     buffer_infos.size() + i + 1;
+        write.pBufferInfo =
+            buffer_infos.empty()
+                ? nullptr
+                : &buffer_infos_.back() - buffer_infos.size() + i + 1;
         write.dstBinding = binding;
         write.dstArrayElement = buffer_infos.at(i).second;
         writes_.push_back(write);

--- a/graphics/Descriptor.cpp
+++ b/graphics/Descriptor.cpp
@@ -203,6 +203,9 @@ DescriptorSetBuilder::DescriptorSetBuilder(
     VkDescriptorSetLayoutCreateFlags layout_flags) {
     allocator_ = allocator;
     layout_ = std::make_shared<DescriptorSetLayout>(allocator_, layout_flags);
+    buffer_infos_.reserve(128);
+    image_infos_.reserve(128);
+    acceleration_structure_infos_.reserve(128);
 }
 
 DescriptorSetBuilder &DescriptorSetBuilder::bind_buffer(
@@ -226,6 +229,39 @@ DescriptorSetBuilder &DescriptorSetBuilder::bind_buffer(
     write.pBufferInfo = &buffer_infos_.back();
     write.dstBinding = binding;
     writes_.push_back(write);
+
+    return *this;
+}
+
+DescriptorSetBuilder &DescriptorSetBuilder::bind_buffers(
+    uint32_t binding,
+    std::vector<std::pair<VkDescriptorBufferInfo, uint32_t>> buffer_infos,
+    VkDescriptorType type, VkShaderStageFlags stages) {
+    VkDescriptorSetLayoutBinding layout_binding{};
+    layout_binding.descriptorCount = MAX_MODELS;
+    layout_binding.descriptorType = type;
+    layout_binding.pImmutableSamplers = nullptr;
+    layout_binding.stageFlags = stages;
+    layout_binding.binding = binding;
+    layout_->add_binding(layout_binding, true);
+
+    for (auto [buffer_info, _] : buffer_infos) {
+        buffer_infos_.push_back(buffer_info);
+    }
+
+    for (size_t i = 0; i < buffer_infos.size(); ++i) {
+        VkWriteDescriptorSet write{};
+        write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        write.pNext = nullptr;
+        write.descriptorCount = 1;
+        write.descriptorType = type;
+        write.pBufferInfo = buffer_infos.empty() ? nullptr
+                                               : &buffer_infos_.back() -
+                                                     buffer_infos.size() + i + 1;
+        write.dstBinding = binding;
+        write.dstArrayElement = buffer_infos.at(i).second;
+        writes_.push_back(write);
+    }
 
     return *this;
 }

--- a/graphics/Descriptor.h
+++ b/graphics/Descriptor.h
@@ -95,6 +95,10 @@ class DescriptorSetBuilder {
                                       VkDescriptorBufferInfo buffer_info,
                                       VkDescriptorType type,
                                       VkShaderStageFlags stages);
+    DescriptorSetBuilder &bind_buffers(
+        uint32_t binding,
+        std::vector<std::pair<VkDescriptorBufferInfo, uint32_t>> buffer_infos,
+        VkDescriptorType type, VkShaderStageFlags stages);
     DescriptorSetBuilder &bind_image(uint32_t binding,
                                      VkDescriptorImageInfo image_info,
                                      VkDescriptorType type,

--- a/graphics/Device.cpp
+++ b/graphics/Device.cpp
@@ -112,11 +112,17 @@ Device::Device(std::shared_ptr<Window> window) : window_(window) {
     queue_create_info.queueCount = 1;
     queue_create_info.pQueuePriorities = &queue_priority;
 
+    VkPhysicalDevice8BitStorageFeatures eight_bit_storage_features{};
+    eight_bit_storage_features.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES;
+    eight_bit_storage_features.storageBuffer8BitAccess = VK_TRUE;
+    eight_bit_storage_features.pNext = nullptr;
+
     VkPhysicalDeviceShaderAtomicInt64Features shader_atomic_int_64_features{};
     shader_atomic_int_64_features.sType =
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
     shader_atomic_int_64_features.shaderBufferInt64Atomics = VK_TRUE;
-    shader_atomic_int_64_features.pNext = nullptr;
+    shader_atomic_int_64_features.pNext = &eight_bit_storage_features;
 
     VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features{};
     timeline_semaphore_features.sType =
@@ -352,10 +358,15 @@ int32_t physical_check_extensions(VkPhysicalDevice physical) {
 }
 
 int32_t physical_check_features_support(VkPhysicalDevice physical) {
+    VkPhysicalDevice8BitStorageFeatures eight_bit_storage_features{};
+    eight_bit_storage_features.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES;
+    eight_bit_storage_features.pNext = nullptr;
+
     VkPhysicalDeviceShaderAtomicInt64Features shader_atomic_int_64_features{};
     shader_atomic_int_64_features.sType =
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
-    shader_atomic_int_64_features.pNext = nullptr;
+    shader_atomic_int_64_features.pNext = &eight_bit_storage_features;
 
     VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features{};
     timeline_semaphore_features.sType =
@@ -410,7 +421,8 @@ int32_t physical_check_features_support(VkPhysicalDevice physical) {
         buffer_device_address_features.bufferDeviceAddress &&
         synchronization_2_features.synchronization2 &&
         timeline_semaphore_features.timelineSemaphore &&
-        shader_atomic_int_64_features.shaderBufferInt64Atomics) {
+        shader_atomic_int_64_features.shaderBufferInt64Atomics &&
+        eight_bit_storage_features.storageBuffer8BitAccess) {
         return 0;
     }
     return -1;

--- a/graphics/Device.cpp
+++ b/graphics/Device.cpp
@@ -112,11 +112,16 @@ Device::Device(std::shared_ptr<Window> window) : window_(window) {
     queue_create_info.queueCount = 1;
     queue_create_info.pQueuePriorities = &queue_priority;
 
+    VkPhysicalDeviceShaderFloat16Int8Features int_eight_features {};
+    int_eight_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES;
+    int_eight_features.shaderInt8 = VK_TRUE;
+    int_eight_features.pNext = nullptr;
+
     VkPhysicalDevice8BitStorageFeatures eight_bit_storage_features{};
     eight_bit_storage_features.sType =
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES;
     eight_bit_storage_features.storageBuffer8BitAccess = VK_TRUE;
-    eight_bit_storage_features.pNext = nullptr;
+    eight_bit_storage_features.pNext = &int_eight_features;
 
     VkPhysicalDeviceShaderAtomicInt64Features shader_atomic_int_64_features{};
     shader_atomic_int_64_features.sType =
@@ -358,10 +363,14 @@ int32_t physical_check_extensions(VkPhysicalDevice physical) {
 }
 
 int32_t physical_check_features_support(VkPhysicalDevice physical) {
+    VkPhysicalDeviceShaderFloat16Int8Features int_eight_features {};
+    int_eight_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES;
+    int_eight_features.pNext = nullptr;
+
     VkPhysicalDevice8BitStorageFeatures eight_bit_storage_features{};
     eight_bit_storage_features.sType =
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES;
-    eight_bit_storage_features.pNext = nullptr;
+    eight_bit_storage_features.pNext = &int_eight_features;
 
     VkPhysicalDeviceShaderAtomicInt64Features shader_atomic_int_64_features{};
     shader_atomic_int_64_features.sType =
@@ -422,7 +431,8 @@ int32_t physical_check_features_support(VkPhysicalDevice physical) {
         synchronization_2_features.synchronization2 &&
         timeline_semaphore_features.timelineSemaphore &&
         shader_atomic_int_64_features.shaderBufferInt64Atomics &&
-        eight_bit_storage_features.storageBuffer8BitAccess) {
+        eight_bit_storage_features.storageBuffer8BitAccess &&
+	int_eight_features.shaderInt8) {
         return 0;
     }
     return -1;

--- a/graphics/Device.cpp
+++ b/graphics/Device.cpp
@@ -112,8 +112,9 @@ Device::Device(std::shared_ptr<Window> window) : window_(window) {
     queue_create_info.queueCount = 1;
     queue_create_info.pQueuePriorities = &queue_priority;
 
-    VkPhysicalDeviceShaderFloat16Int8Features int_eight_features {};
-    int_eight_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES;
+    VkPhysicalDeviceShaderFloat16Int8Features int_eight_features{};
+    int_eight_features.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES;
     int_eight_features.shaderInt8 = VK_TRUE;
     int_eight_features.pNext = nullptr;
 
@@ -363,8 +364,9 @@ int32_t physical_check_extensions(VkPhysicalDevice physical) {
 }
 
 int32_t physical_check_features_support(VkPhysicalDevice physical) {
-    VkPhysicalDeviceShaderFloat16Int8Features int_eight_features {};
-    int_eight_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES;
+    VkPhysicalDeviceShaderFloat16Int8Features int_eight_features{};
+    int_eight_features.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES;
     int_eight_features.pNext = nullptr;
 
     VkPhysicalDevice8BitStorageFeatures eight_bit_storage_features{};
@@ -432,7 +434,7 @@ int32_t physical_check_features_support(VkPhysicalDevice physical) {
         timeline_semaphore_features.timelineSemaphore &&
         shader_atomic_int_64_features.shaderBufferInt64Atomics &&
         eight_bit_storage_features.storageBuffer8BitAccess &&
-	int_eight_features.shaderInt8) {
+        int_eight_features.shaderInt8) {
         return 0;
     }
     return -1;

--- a/graphics/Geometry.cpp
+++ b/graphics/Geometry.cpp
@@ -63,9 +63,8 @@ BLAS::BLAS(std::shared_ptr<GPUAllocator> allocator,
     blas_build_geometry_info.type =
         VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
     blas_build_geometry_info.flags =
-        VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR |
-        VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR |
-        VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR;
+        VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR |
+    VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR;
     blas_build_geometry_info.mode =
         VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
     blas_build_geometry_info.geometryCount = 1;
@@ -200,7 +199,7 @@ TLAS::TLAS(std::shared_ptr<GPUAllocator> allocator,
     tlas_build_geometry_info.type =
         VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
     tlas_build_geometry_info.flags =
-        VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR;
+        VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR | VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR;
     tlas_build_geometry_info.mode =
         VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
     tlas_build_geometry_info.geometryCount = 1;
@@ -275,10 +274,12 @@ TLAS::TLAS(std::shared_ptr<GPUAllocator> allocator,
 void TLAS::update_model_sbt_offsets(
     std::unordered_map<uint64_t, uint32_t> models) {
     for (auto &instance : instances_) {
-        auto it = models.find(instance.instanceCustomIndex);
-        if (it != models.end()) {
-            instance.instanceShaderBindingTableRecordOffset = it->second;
-        }
+	if (instance.instanceShaderBindingTableRecordOffset == UNLOADED_SBT_OFFSET) {
+	    auto it = models.find(instance.instanceCustomIndex);
+	    if (it != models.end()) {
+		instance.instanceShaderBindingTableRecordOffset = it->second;
+	    }
+	}
     }
     timeline_ = std::make_shared<Semaphore>(command_pool_->get_device(), true);
     timeline_->set_signal_value(INSTANCES_BUFFER_TIMELINE);
@@ -314,9 +315,9 @@ void TLAS::update_model_sbt_offsets(
     tlas_build_geometry_info.type =
         VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
     tlas_build_geometry_info.flags =
-        VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR;
+        VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR | VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR;
     tlas_build_geometry_info.mode =
-        VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
+        VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR;
     tlas_build_geometry_info.srcAccelerationStructure = tlas_;
     tlas_build_geometry_info.dstAccelerationStructure = tlas_;
     tlas_build_geometry_info.scratchData.deviceAddress =

--- a/graphics/Geometry.cpp
+++ b/graphics/Geometry.cpp
@@ -132,7 +132,7 @@ BLAS::~BLAS() {
         nullptr);
 }
 
-VkAccelerationStructureKHR BLAS::get_blas() { return blas_; }
+VkAccelerationStructureKHR &BLAS::get_blas() { return blas_; }
 
 std::shared_ptr<Semaphore> BLAS::get_timeline() { return timeline_; }
 
@@ -348,7 +348,7 @@ TLAS::~TLAS() {
         nullptr);
 }
 
-VkAccelerationStructureKHR TLAS::get_tlas() { return tlas_; }
+VkAccelerationStructureKHR &TLAS::get_tlas() { return tlas_; }
 
 std::shared_ptr<Semaphore> TLAS::get_timeline() { return timeline_; }
 

--- a/graphics/Geometry.cpp
+++ b/graphics/Geometry.cpp
@@ -64,7 +64,7 @@ BLAS::BLAS(std::shared_ptr<GPUAllocator> allocator,
         VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
     blas_build_geometry_info.flags =
         VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR |
-    VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR;
+        VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR;
     blas_build_geometry_info.mode =
         VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
     blas_build_geometry_info.geometryCount = 1;
@@ -199,7 +199,8 @@ TLAS::TLAS(std::shared_ptr<GPUAllocator> allocator,
     tlas_build_geometry_info.type =
         VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
     tlas_build_geometry_info.flags =
-        VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR | VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR;
+        VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR |
+        VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR;
     tlas_build_geometry_info.mode =
         VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
     tlas_build_geometry_info.geometryCount = 1;
@@ -274,12 +275,13 @@ TLAS::TLAS(std::shared_ptr<GPUAllocator> allocator,
 void TLAS::update_model_sbt_offsets(
     std::unordered_map<uint64_t, uint32_t> models) {
     for (auto &instance : instances_) {
-	if (instance.instanceShaderBindingTableRecordOffset == UNLOADED_SBT_OFFSET) {
-	    auto it = models.find(instance.instanceCustomIndex);
-	    if (it != models.end()) {
-		instance.instanceShaderBindingTableRecordOffset = it->second;
-	    }
-	}
+        if (instance.instanceShaderBindingTableRecordOffset ==
+            UNLOADED_SBT_OFFSET) {
+            auto it = models.find(instance.instanceCustomIndex);
+            if (it != models.end()) {
+                instance.instanceShaderBindingTableRecordOffset = it->second;
+            }
+        }
     }
     timeline_ = std::make_shared<Semaphore>(command_pool_->get_device(), true);
     timeline_->set_signal_value(INSTANCES_BUFFER_TIMELINE);
@@ -315,7 +317,8 @@ void TLAS::update_model_sbt_offsets(
     tlas_build_geometry_info.type =
         VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
     tlas_build_geometry_info.flags =
-        VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR | VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR;
+        VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR |
+        VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR;
     tlas_build_geometry_info.mode =
         VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR;
     tlas_build_geometry_info.srcAccelerationStructure = tlas_;

--- a/graphics/Geometry.h
+++ b/graphics/Geometry.h
@@ -15,7 +15,7 @@ class BLAS {
          std::vector<VkAabbPositionsKHR> aabbs);
     ~BLAS();
 
-    VkAccelerationStructureKHR get_blas();
+    VkAccelerationStructureKHR &get_blas();
 
     std::shared_ptr<Semaphore> get_timeline();
 
@@ -45,7 +45,7 @@ class TLAS {
     void
     update_model_sbt_offsets(std::unordered_map<uint64_t, uint32_t> models);
 
-    VkAccelerationStructureKHR get_tlas();
+    VkAccelerationStructureKHR &get_tlas();
 
     std::shared_ptr<Semaphore> get_timeline();
 

--- a/graphics/Geometry.h
+++ b/graphics/Geometry.h
@@ -5,6 +5,8 @@
 #include "GPUAllocator.h"
 #include "RingBuffer.h"
 
+static const uint32_t UNLOADED_SBT_OFFSET = 0;
+
 class BLAS {
   public:
     BLAS(std::shared_ptr<GPUAllocator> allocator,

--- a/graphics/GraphicsContext.cpp
+++ b/graphics/GraphicsContext.cpp
@@ -412,7 +412,7 @@ void GraphicsContext::bind_scene_descriptors(DescriptorSetBuilder &builder, std:
                 raw_volume_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
                 raw_volume_infos.emplace_back(raw_volume_info, i);
             } else if (model->chunk_->get_state() == VoxelChunk::State::GPU &&
-                       model->chunk_->get_format() == VoxelChunk::Format::Raw) {
+                       model->chunk_->get_format() == VoxelChunk::Format::SVO) {
                 auto buffer = model->chunk_->get_gpu_buffer();
                 VkDescriptorBufferInfo svo_buffer_info{};
                 svo_buffer_info.buffer = buffer->get_buffer();

--- a/graphics/GraphicsContext.cpp
+++ b/graphics/GraphicsContext.cpp
@@ -14,7 +14,6 @@
 #include "Synchronization.h"
 #include "Window.h"
 
-const uint32_t UNLOADED_SBT_OFFSET = 0;
 const std::map<std::pair<VoxelChunk::Format, VoxelChunk::AttributeSet>,
                uint32_t>
     FORMAT_TO_SBT_OFFSET = {

--- a/graphics/GraphicsContext.cpp
+++ b/graphics/GraphicsContext.cpp
@@ -18,6 +18,7 @@ const std::map<std::pair<VoxelChunk::Format, VoxelChunk::AttributeSet>,
                uint32_t>
     FORMAT_TO_SBT_OFFSET = {
         {{VoxelChunk::Format::Raw, VoxelChunk::AttributeSet::Color}, 1},
+        {{VoxelChunk::Format::SVO, VoxelChunk::AttributeSet::Color}, 2},
 };
 const uint64_t MAX_NUM_CHUNKS_LOADED_PER_FRAME = 32;
 
@@ -125,6 +126,9 @@ GraphicsContext::GraphicsContext() {
     scene_builder.bind_images(1, {}, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
                               VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
                                   VK_SHADER_STAGE_INTERSECTION_BIT_KHR);
+    scene_builder.bind_buffers(2, {}, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                               VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
+                                   VK_SHADER_STAGE_INTERSECTION_BIT_KHR);
 
     unloaded_chunks_buffer_ = std::make_shared<GPUBuffer>(
         gpu_allocator_, MAX_NUM_CHUNKS_LOADED_PER_FRAME * sizeof(uint64_t),
@@ -152,11 +156,15 @@ GraphicsContext::GraphicsContext() {
     auto unloaded_rint = std::make_shared<Shader>(device_, "Unloaded_rint");
     auto raw_color_rchit = std::make_shared<Shader>(device_, "Raw_Color_rchit");
     auto raw_color_rint = std::make_shared<Shader>(device_, "Raw_Color_rint");
+    auto svo_color_rchit = std::make_shared<Shader>(device_, "SVO_Color_rchit");
+    auto svo_color_rint = std::make_shared<Shader>(device_, "SVO_Color_rint");
     std::vector<std::vector<std::shared_ptr<Shader>>> shader_groups = {
         {rgen},
         {rmiss},
         {unloaded_rchit, unloaded_rint},
-        {raw_color_rchit, raw_color_rint}};
+        {raw_color_rchit, raw_color_rint},
+        {svo_color_rchit, svo_color_rint},
+    };
     std::vector<VkDescriptorSetLayout> layouts = {
         swapchain_->get_image_descriptor(0)->get_layout(),
         scene_builder.get_layout()->get_layout(),
@@ -332,20 +340,33 @@ build_scene(std::shared_ptr<GraphicsContext> context,
                                         },
                                         VK_SHADER_STAGE_RAYGEN_BIT_KHR);
 
-    std::vector<std::pair<VkDescriptorImageInfo, uint32_t>> image_infos;
+    std::vector<std::pair<VkDescriptorImageInfo, uint32_t>> raw_volume_infos;
+    std::vector<std::pair<VkDescriptorBufferInfo, uint32_t>> svo_buffer_infos;
     for (auto [model, idx] : referenced_models) {
-        if (model->chunk_->get_state() == VoxelChunk::State::GPU) {
+        if (model->chunk_->get_state() == VoxelChunk::State::GPU &&
+            model->chunk_->get_format() == VoxelChunk::Format::Raw) {
             auto volume = model->chunk_->get_gpu_volume();
-            VkDescriptorImageInfo image_info{};
-            image_info.imageView = volume->get_view();
-            image_info.sampler = VK_NULL_HANDLE;
-            image_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-            image_infos.emplace_back(image_info, idx);
+            VkDescriptorImageInfo raw_volume_info{};
+            raw_volume_info.imageView = volume->get_view();
+            raw_volume_info.sampler = VK_NULL_HANDLE;
+            raw_volume_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+            raw_volume_infos.emplace_back(raw_volume_info, idx);
+        } else if (model->chunk_->get_state() == VoxelChunk::State::GPU &&
+                   model->chunk_->get_format() == VoxelChunk::Format::Raw) {
+            auto buffer = model->chunk_->get_gpu_buffer();
+            VkDescriptorBufferInfo svo_buffer_info{};
+            svo_buffer_info.buffer = buffer->get_buffer();
+            svo_buffer_info.offset = 0;
+            svo_buffer_info.range = buffer->get_size();
+            svo_buffer_infos.emplace_back(svo_buffer_info, idx);
         }
     }
-    builder.bind_images(1, image_infos, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+    builder.bind_images(1, raw_volume_infos, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
                         VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
                             VK_SHADER_STAGE_INTERSECTION_BIT_KHR);
+    builder.bind_buffers(2, svo_buffer_infos, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                         VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
+                             VK_SHADER_STAGE_INTERSECTION_BIT_KHR);
 
     auto scene_descriptor = builder.build();
     return std::make_shared<GraphicsScene>(tlas, objects, scene_descriptor);
@@ -398,21 +419,38 @@ void GraphicsContext::check_chunk_request_buffer(
             },
             VK_SHADER_STAGE_RAYGEN_BIT_KHR);
 
-        std::vector<std::pair<VkDescriptorImageInfo, uint32_t>> image_infos;
+        std::vector<std::pair<VkDescriptorImageInfo, uint32_t>>
+            raw_volume_infos;
+        std::vector<std::pair<VkDescriptorBufferInfo, uint32_t>>
+            svo_buffer_infos;
         for (size_t i = 0; i < scene_models.size(); ++i) {
             const auto &model = scene_models.at(i);
-            if (model->chunk_->get_state() == VoxelChunk::State::GPU) {
+            if (model->chunk_->get_state() == VoxelChunk::State::GPU &&
+                model->chunk_->get_format() == VoxelChunk::Format::Raw) {
                 auto volume = model->chunk_->get_gpu_volume();
-                VkDescriptorImageInfo image_info{};
-                image_info.imageView = volume->get_view();
-                image_info.sampler = VK_NULL_HANDLE;
-                image_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-                image_infos.emplace_back(image_info, i);
+                VkDescriptorImageInfo raw_volume_info{};
+                raw_volume_info.imageView = volume->get_view();
+                raw_volume_info.sampler = VK_NULL_HANDLE;
+                raw_volume_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+                raw_volume_infos.emplace_back(raw_volume_info, i);
+            } else if (model->chunk_->get_state() == VoxelChunk::State::GPU &&
+                       model->chunk_->get_format() == VoxelChunk::Format::Raw) {
+                auto buffer = model->chunk_->get_gpu_buffer();
+                VkDescriptorBufferInfo svo_buffer_info{};
+                svo_buffer_info.buffer = buffer->get_buffer();
+                svo_buffer_info.offset = 0;
+                svo_buffer_info.range = buffer->get_size();
+                svo_buffer_infos.emplace_back(svo_buffer_info, i);
             }
         }
-        builder.bind_images(1, image_infos, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+        builder.bind_images(1, raw_volume_infos,
+                            VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
                             VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
                                 VK_SHADER_STAGE_INTERSECTION_BIT_KHR);
+        builder.bind_buffers(2, svo_buffer_infos,
+                             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                             VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
+                                 VK_SHADER_STAGE_INTERSECTION_BIT_KHR);
         builder.update(current_scene_->scene_descriptor_);
     }
 }

--- a/graphics/Pipeline.cpp
+++ b/graphics/Pipeline.cpp
@@ -1,6 +1,6 @@
+#include <cstring>
 #include <filesystem>
 #include <fstream>
-#include <cstring>
 #include <vector>
 
 #include "Pipeline.h"

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -7,6 +7,8 @@ set(GLSL_SHADER_FILES
   rmiss.glsl
   Raw_Color_rchit.glsl
   Raw_Color_rint.glsl
+  SVO_Color_rchit.glsl
+  SVO_Color_rint.glsl
   Unloaded_rchit.glsl
   Unloaded_rint.glsl
 )

--- a/shaders/Raw_Color_rint.glsl
+++ b/shaders/Raw_Color_rint.glsl
@@ -54,7 +54,7 @@ void main() {
 	    float palette = imageLoad(volumes[volume_id], obj_ray_voxel).a;
 	    
 	    if (palette > 0.0) {
-		r = hit_aabb(vec3(obj_ray_voxel) / volume_size, vec3(obj_ray_voxel + 1) / volume_size, obj_ray_pos, obj_ray_dir);
+		aabb_intersect_result r = hit_aabb(vec3(obj_ray_voxel) / volume_size, vec3(obj_ray_voxel + 1) / volume_size, obj_ray_pos, obj_ray_dir);
 		vec3 obj_ray_voxel_intersect_point = obj_ray_pos + obj_ray_dir * max(r.front_t, 0.0);
 		float intersect_time = length(gl_ObjectToWorldEXT * vec4(obj_ray_voxel_intersect_point, 1.0) - gl_ObjectToWorldEXT * vec4(obj_ray_pos, 1.0));
 		reportIntersectionEXT(intersect_time, r.k);

--- a/shaders/SVO_Color_rchit.glsl
+++ b/shaders/SVO_Color_rchit.glsl
@@ -7,9 +7,11 @@
 
 layout(location = 0) rayPayloadInEXT vec4 hit;
 
+hitAttributeEXT uint leaf_id;
+
 void main() {
     uint svo_id = gl_InstanceCustomIndexEXT;
-    SVOLeaf_Color color = svo_leaf_color_buffers[svo_id].nodes[gl_HitKindEXT];
+    SVOLeaf_Color color = svo_leaf_color_buffers[svo_id].nodes[leaf_id];
     hit = vec4(
 	       float(int(color.red_)) / 255.0,
 	       float(int(color.green_)) / 255.0,

--- a/shaders/SVO_Color_rchit.glsl
+++ b/shaders/SVO_Color_rchit.glsl
@@ -8,5 +8,12 @@
 layout(location = 0) rayPayloadInEXT vec4 hit;
 
 void main() {
-    hit = vec4(1.0, 0.0, 1.0, 1.0);
+    uint svo_id = gl_InstanceCustomIndexEXT;
+    SVOLeaf_Color color = svo_leaf_color_buffers[svo_id].nodes[gl_HitKindEXT];
+    hit = vec4(
+	       float(int(color.red_)) / 255.0,
+	       float(int(color.green_)) / 255.0,
+	       float(int(color.blue_)) / 255.0,
+	       float(int(color.alpha_)) / 255.0
+	       );
 }

--- a/shaders/SVO_Color_rchit.glsl
+++ b/shaders/SVO_Color_rchit.glsl
@@ -1,0 +1,12 @@
+#version 460
+#pragma shader_stage(closest)
+#extension GL_EXT_ray_tracing : enable
+#extension GL_GOOGLE_include_directive : enable
+
+#include "common.glsl"
+
+layout(location = 0) rayPayloadInEXT vec4 hit;
+
+void main() {
+    hit = vec4(1.0, 0.0, 1.0, 1.0);
+}

--- a/shaders/SVO_Color_rint.glsl
+++ b/shaders/SVO_Color_rint.glsl
@@ -1,0 +1,46 @@
+#version 460
+#pragma shader_stage(intersect)
+#extension GL_EXT_ray_tracing : enable
+#extension GL_GOOGLE_include_directive : enable
+
+#include "common.glsl"
+
+struct aabb_intersect_result {
+    float front_t;
+    float back_t;
+    uint k;
+};
+
+aabb_intersect_result hit_aabb(const vec3 minimum, const vec3 maximum, const vec3 origin, const vec3 direction) {
+    aabb_intersect_result r;
+    vec3 invDir = 1.0 / direction;
+    vec3 tbot = invDir * (minimum - origin);
+    vec3 ttop = invDir * (maximum - origin);
+    vec3 tmin = min(ttop, tbot);
+    vec3 tmax = max(ttop, tbot);
+    float t0 = max(tmin.x, max(tmin.y, tmin.z));
+    float t1 = min(tmax.x, min(tmax.y, tmax.z));
+    r.front_t = t1 > max(t0, 0.0) ? t0 : -FAR_AWAY;
+    r.back_t = t1 > max(t0, 0.0) ? t1 : -FAR_AWAY;
+    if (t0 == tmin.x) {
+	r.k = tbot.x > ttop.x ? 1 : 0;
+    } else if (t0 == tmin.y) {
+	r.k = tbot.y > ttop.y ? 3 : 2;
+    } else if (t0 == tmin.z) {
+	r.k = tbot.z > ttop.z ? 5 : 4;
+    }
+    return r;
+}
+
+void main() {
+    uint volume_id = gl_InstanceCustomIndexEXT;
+
+    vec3 obj_ray_pos = gl_WorldToObjectEXT * vec4(gl_WorldRayOriginEXT, 1.0);
+    vec3 obj_ray_dir = gl_WorldToObjectEXT * vec4(gl_WorldRayDirectionEXT, 0.0);
+
+    aabb_intersect_result r = hit_aabb(vec3(0.0), vec3(1.0), obj_ray_pos, obj_ray_dir);
+
+    if (r.front_t != -FAR_AWAY) {
+	reportIntersectionEXT(r.front_t, 0);
+    }
+}

--- a/shaders/SVO_Color_rint.glsl
+++ b/shaders/SVO_Color_rint.glsl
@@ -7,12 +7,10 @@
 
 hitAttributeEXT uint leaf_id;
 
-#define MAX_DEPTH 12
+#define MAX_DEPTH 32
 
 struct aabb_intersect_result {
     float front_t;
-    float back_t;
-    uint k;
 };
 
 aabb_intersect_result hit_aabb(const vec3 minimum, const vec3 maximum, const vec3 origin, const vec3 direction) {
@@ -25,14 +23,6 @@ aabb_intersect_result hit_aabb(const vec3 minimum, const vec3 maximum, const vec
     float t0 = max(tmin.x, max(tmin.y, tmin.z));
     float t1 = min(tmax.x, min(tmax.y, tmax.z));
     r.front_t = t1 > max(t0, 0.0) ? t0 : -FAR_AWAY;
-    r.back_t = t1 > max(t0, 0.0) ? t1 : -FAR_AWAY;
-    if (t0 == tmin.x) {
-	r.k = tbot.x > ttop.x ? 1 : 0;
-    } else if (t0 == tmin.y) {
-	r.k = tbot.y > ttop.y ? 3 : 2;
-    } else if (t0 == tmin.z) {
-	r.k = tbot.z > ttop.z ? 5 : 4;
-    }
     return r;
 }
 
@@ -47,34 +37,23 @@ const vec3 subpositions[8] = vec3[8](
 				     vec3(0.5, 0.5, 0.5)
 				     );
 
-const uint8_t children_iteration_order[8][8] = uint8_t[8][8](
-							     uint8_t[8](uint8_t(0), uint8_t(1), uint8_t(2), uint8_t(3), uint8_t(4), uint8_t(5), uint8_t(6), uint8_t(7)),
-							     uint8_t[8](uint8_t(1), uint8_t(0), uint8_t(3), uint8_t(2), uint8_t(5), uint8_t(4), uint8_t(7), uint8_t(6)),
-							     uint8_t[8](uint8_t(2), uint8_t(3), uint8_t(0), uint8_t(1), uint8_t(6), uint8_t(7), uint8_t(4), uint8_t(5)),
-							     uint8_t[8](uint8_t(3), uint8_t(2), uint8_t(1), uint8_t(0), uint8_t(7), uint8_t(6), uint8_t(5), uint8_t(4)),
-							     uint8_t[8](uint8_t(4), uint8_t(5), uint8_t(6), uint8_t(7), uint8_t(0), uint8_t(1), uint8_t(2), uint8_t(3)),
-							     uint8_t[8](uint8_t(5), uint8_t(4), uint8_t(7), uint8_t(6), uint8_t(1), uint8_t(0), uint8_t(3), uint8_t(2)),
-							     uint8_t[8](uint8_t(6), uint8_t(7), uint8_t(4), uint8_t(5), uint8_t(2), uint8_t(3), uint8_t(0), uint8_t(1)),
-							     uint8_t[8](uint8_t(7), uint8_t(6), uint8_t(5), uint8_t(4), uint8_t(3), uint8_t(2), uint8_t(1), uint8_t(0))
-							     );
+const uint children_iteration_order[8][8] = uint[8][8](
+						       uint[8](0, 1, 2, 3, 4, 5, 6, 7),
+						       uint[8](1, 0, 3, 2, 5, 4, 7, 6),
+						       uint[8](2, 3, 0, 1, 6, 7, 4, 5),
+						       uint[8](3, 2, 1, 0, 7, 6, 5, 4),
+						       uint[8](4, 5, 6, 7, 0, 1, 2, 3),
+						       uint[8](5, 4, 7, 6, 1, 0, 3, 2),
+						       uint[8](6, 7, 4, 5, 2, 3, 0, 1),
+						       uint[8](7, 6, 5, 4, 3, 2, 1, 0)
+						       );
 
 struct SVOMarchStackFrame {
     uint node_id;
+    uint left_off;
     vec3 low;
     vec3 high;
-    uint8_t[8] expanded_indices;
-    uint8_t valid_mask;
 };
-
-void construct_expanded_indices(uint8_t valid_mask, inout uint8_t[8] expanded_indices) {
-    uint8_t num_valid = uint8_t(0);
-    for (int child = 0; child < 8; ++child) {
-	expanded_indices[child] = num_valid;
-	if (bool((valid_mask >> (7 - child)) & 1)) {
-	    ++num_valid;
-	}
-    }
-}
 
 void main() {
     uint svo_id = gl_InstanceCustomIndexEXT;
@@ -89,19 +68,17 @@ void main() {
 	int level = 0;
 	SVOMarchStackFrame stack[MAX_DEPTH];
 	stack[level].node_id = svo_buffers[svo_id].num_nodes - 1;
-	stack[level].valid_mask = uint8_t(0xFF);
-	construct_expanded_indices(svo_buffers[svo_id].nodes[stack[level].node_id].valid_mask_, stack[level].expanded_indices);
+	stack[level].left_off = 0;
 	stack[level].low = vec3(0.0);
 	stack[level].high = vec3(1.0);
 	while (level >= 0 && level < MAX_DEPTH) {
 	    uint curr_node = stack[level].node_id;
-	    int valid = stack[level].valid_mask & svo_buffers[svo_id].nodes[curr_node].valid_mask_;
-	    for (int idx = 0; idx < 8; ++idx) {
+	    int valid_mask = svo_buffers[svo_id].nodes[curr_node].valid_mask_;
+	    for (uint idx = stack[level].left_off; idx < 8; ++idx) {
 		int child = int(children_iteration_order[direction_kind][idx]);
-		int valid = valid >> (7 - child);
+		int valid = valid_mask >> (7 - child);
 		valid &= 1;
 		if (bool(valid)) {
-		    stack[level].valid_mask ^= uint8_t(1 << (7 - child));
 		    vec3 diff = stack[level].high - stack[level].low;
 		    vec3 sub_low = stack[level].low + subpositions[child] * diff;
 		    vec3 sub_high = sub_low + diff * 0.5;
@@ -110,7 +87,15 @@ void main() {
 			int leaf = svo_buffers[svo_id].nodes[curr_node].leaf_mask_;
 			leaf >>= (7 - child);
 			leaf &= 1;
-			uint child_node_id = svo_buffers[svo_id].nodes[curr_node].child_pointer_ + stack[level].expanded_indices[child];
+			uint8_t[8] expanded_indices;
+			uint8_t num_valid = uint8_t(0);
+			for (int child = 0; child < 8; ++child) {
+			    expanded_indices[child] = num_valid;
+			    if (bool((valid_mask >> (7 - child)) & 1)) {
+				++num_valid;
+			    }
+			}
+			uint child_node_id = svo_buffers[svo_id].nodes[curr_node].child_pointer_ + expanded_indices[child];
 			if (bool(leaf)) {
 			    vec3 obj_ray_voxel_intersect_point = obj_ray_pos + obj_ray_dir * max(r.front_t, 0.0);
 			    float intersect_time = length(gl_ObjectToWorldEXT * vec4(obj_ray_voxel_intersect_point, 1.0) - gl_ObjectToWorldEXT * vec4(obj_ray_pos, 1.0));
@@ -118,10 +103,10 @@ void main() {
 			    reportIntersectionEXT(intersect_time, 0);
 			    return;
 			} else {
+			    stack[level].left_off = idx + 1;
 			    ++level;
 			    stack[level].node_id = child_node_id;
-			    stack[level].valid_mask = uint8_t(0xFF);
-			    construct_expanded_indices(svo_buffers[svo_id].nodes[stack[level].node_id].valid_mask_, stack[level].expanded_indices);
+			    stack[level].left_off = 0;
 			    stack[level].low = sub_low;
 			    stack[level].high = sub_high;
 			    ++level;

--- a/shaders/SVO_Color_rint.glsl
+++ b/shaders/SVO_Color_rint.glsl
@@ -33,14 +33,15 @@ aabb_intersect_result hit_aabb(const vec3 minimum, const vec3 maximum, const vec
 }
 
 void main() {
-    uint volume_id = gl_InstanceCustomIndexEXT;
+    uint svo_id = gl_InstanceCustomIndexEXT;
 
     vec3 obj_ray_pos = gl_WorldToObjectEXT * vec4(gl_WorldRayOriginEXT, 1.0);
     vec3 obj_ray_dir = gl_WorldToObjectEXT * vec4(gl_WorldRayDirectionEXT, 0.0);
 
     aabb_intersect_result r = hit_aabb(vec3(0.0), vec3(1.0), obj_ray_pos, obj_ray_dir);
-
     if (r.front_t != -FAR_AWAY) {
-	reportIntersectionEXT(r.front_t, 0);
+	if (svo_buffers[svo_id].num_nodes == 1888) {
+	    reportIntersectionEXT(r.front_t, 0);
+	}
     }
 }

--- a/shaders/SVO_Color_rint.glsl
+++ b/shaders/SVO_Color_rint.glsl
@@ -47,13 +47,34 @@ const vec3 subpositions[8] = vec3[8](
 				     vec3(0.5, 0.5, 0.5)
 				     );
 
+const uint8_t children_iteration_order[8][8] = uint8_t[8][8](
+							     uint8_t[8](uint8_t(0), uint8_t(1), uint8_t(2), uint8_t(3), uint8_t(4), uint8_t(5), uint8_t(6), uint8_t(7)),
+							     uint8_t[8](uint8_t(1), uint8_t(0), uint8_t(3), uint8_t(2), uint8_t(5), uint8_t(4), uint8_t(7), uint8_t(6)),
+							     uint8_t[8](uint8_t(2), uint8_t(3), uint8_t(0), uint8_t(1), uint8_t(6), uint8_t(7), uint8_t(4), uint8_t(5)),
+							     uint8_t[8](uint8_t(3), uint8_t(2), uint8_t(1), uint8_t(0), uint8_t(7), uint8_t(6), uint8_t(5), uint8_t(4)),
+							     uint8_t[8](uint8_t(4), uint8_t(5), uint8_t(6), uint8_t(7), uint8_t(0), uint8_t(1), uint8_t(2), uint8_t(3)),
+							     uint8_t[8](uint8_t(5), uint8_t(4), uint8_t(7), uint8_t(6), uint8_t(1), uint8_t(0), uint8_t(3), uint8_t(2)),
+							     uint8_t[8](uint8_t(6), uint8_t(7), uint8_t(4), uint8_t(5), uint8_t(2), uint8_t(3), uint8_t(0), uint8_t(1)),
+							     uint8_t[8](uint8_t(7), uint8_t(6), uint8_t(5), uint8_t(4), uint8_t(3), uint8_t(2), uint8_t(1), uint8_t(0))
+							     );
+
 struct SVOMarchStackFrame {
     uint node_id;
-    uint8_t valid_mask;
-    uint8_t num_valid;
     vec3 low;
     vec3 high;
+    uint8_t[8] expanded_indices;
+    uint8_t valid_mask;
 };
+
+void construct_expanded_indices(uint8_t valid_mask, inout uint8_t[8] expanded_indices) {
+    uint8_t num_valid = uint8_t(0);
+    for (int child = 0; child < 8; ++child) {
+	expanded_indices[child] = num_valid;
+	if (bool((valid_mask >> (7 - child)) & 1)) {
+	    ++num_valid;
+	}
+    }
+}
 
 void main() {
     uint svo_id = gl_InstanceCustomIndexEXT;
@@ -61,48 +82,46 @@ void main() {
     vec3 obj_ray_pos = gl_WorldToObjectEXT * vec4(gl_WorldRayOriginEXT, 1.0);
     vec3 obj_ray_dir = gl_WorldToObjectEXT * vec4(gl_WorldRayDirectionEXT, 0.0);
 
+    int direction_kind = int(obj_ray_dir.x < 0.0) + 2 * int(obj_ray_dir.y < 0.0) + 4 * int(obj_ray_dir.z < 0.0);
+
     aabb_intersect_result r = hit_aabb(vec3(0.0), vec3(1.0), obj_ray_pos, obj_ray_dir);
     if (r.front_t != -FAR_AWAY) {
-	float best_intersect_time = 100000.0;
 	int level = 0;
 	SVOMarchStackFrame stack[MAX_DEPTH];
 	stack[level].node_id = svo_buffers[svo_id].num_nodes - 1;
 	stack[level].valid_mask = uint8_t(0xFF);
-	stack[level].num_valid = uint8_t(0);
+	construct_expanded_indices(svo_buffers[svo_id].nodes[stack[level].node_id].valid_mask_, stack[level].expanded_indices);
 	stack[level].low = vec3(0.0);
 	stack[level].high = vec3(1.0);
 	while (level >= 0 && level < MAX_DEPTH) {
 	    uint curr_node = stack[level].node_id;
 	    int valid = stack[level].valid_mask & svo_buffers[svo_id].nodes[curr_node].valid_mask_;
-	    for (int child = 0; child < 8; ++child) {
+	    for (int idx = 0; idx < 8; ++idx) {
+		int child = int(children_iteration_order[direction_kind][idx]);
 		int valid = valid >> (7 - child);
 		valid &= 1;
 		if (bool(valid)) {
 		    stack[level].valid_mask ^= uint8_t(1 << (7 - child));
-		    uint8_t old_num_valid = stack[level].num_valid;
-		    ++stack[level].num_valid;
 		    vec3 diff = stack[level].high - stack[level].low;
 		    vec3 sub_low = stack[level].low + subpositions[child] * diff;
 		    vec3 sub_high = sub_low + diff * 0.5;
 		    aabb_intersect_result r = hit_aabb(sub_low, sub_high, obj_ray_pos, obj_ray_dir);
-		    if (r.front_t != -FAR_AWAY && r.front_t < best_intersect_time) {
+		    if (r.front_t != -FAR_AWAY) {
 			int leaf = svo_buffers[svo_id].nodes[curr_node].leaf_mask_;
 			leaf >>= (7 - child);
 			leaf &= 1;
-			uint child_node_id = svo_buffers[svo_id].nodes[curr_node].child_pointer_ + old_num_valid;
+			uint child_node_id = svo_buffers[svo_id].nodes[curr_node].child_pointer_ + stack[level].expanded_indices[child];
 			if (bool(leaf)) {
 			    vec3 obj_ray_voxel_intersect_point = obj_ray_pos + obj_ray_dir * max(r.front_t, 0.0);
 			    float intersect_time = length(gl_ObjectToWorldEXT * vec4(obj_ray_voxel_intersect_point, 1.0) - gl_ObjectToWorldEXT * vec4(obj_ray_pos, 1.0));
-			    if (intersect_time < best_intersect_time) {
-				leaf_id = child_node_id;
-				best_intersect_time = intersect_time;
-				reportIntersectionEXT(best_intersect_time, 0);
-			    }
+			    leaf_id = child_node_id;
+			    reportIntersectionEXT(intersect_time, 0);
+			    return;
 			} else {
 			    ++level;
 			    stack[level].node_id = child_node_id;
 			    stack[level].valid_mask = uint8_t(0xFF);
-			    stack[level].num_valid = uint8_t(0);
+			    construct_expanded_indices(svo_buffers[svo_id].nodes[stack[level].node_id].valid_mask_, stack[level].expanded_indices);
 			    stack[level].low = sub_low;
 			    stack[level].high = sub_high;
 			    ++level;

--- a/shaders/Unloaded_rint.glsl
+++ b/shaders/Unloaded_rint.glsl
@@ -6,7 +6,7 @@
 #include "common.glsl"
 
 void main() {
-    uint64_t volume_id = gl_InstanceCustomIndexEXT;
-    int crb_idx = int(volume_id % MAX_NUM_CHUNKS_LOADED_PER_FRAME);
-    atomicExchange(chunk_request_buffer[crb_idx], volume_id);
+    uint64_t model_id = gl_InstanceCustomIndexEXT;
+    int crb_idx = int(model_id % MAX_NUM_CHUNKS_LOADED_PER_FRAME);
+    atomicExchange(chunk_request_buffer[crb_idx], model_id);
 }

--- a/shaders/common.glsl
+++ b/shaders/common.glsl
@@ -37,7 +37,13 @@ layout(set = 1, binding = 2) buffer SVOBuffer {
     uint32_t num_nodes;
     SVONode nodes[];
 } svo_buffers[];
-layout(set = 1, binding = 2) buffer SVOBuffer_Color { SVOLeaf_Color nodes[]; } svo_leaf_color_buffers[];
+layout(set = 1, binding = 2) buffer SVOBuffer_Color {
+    uint32_t voxel_width;
+    uint32_t voxel_height;
+    uint32_t voxel_depth;
+    uint32_t num_nodes;
+    SVOLeaf_Color nodes[];
+} svo_leaf_color_buffers[];
 
 // Set 2 is not swapped out - it is for GraphicsContext-wide data.
 #define MAX_NUM_CHUNKS_LOADED_PER_FRAME 32

--- a/shaders/common.glsl
+++ b/shaders/common.glsl
@@ -1,6 +1,15 @@
 #extension GL_EXT_nonuniform_qualifier : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int64 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int32 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_atomic_int64 : require
+
+struct SVONode {
+    uint32_t child_pointer_;
+    uint8_t valid_mask_;
+    uint8_t leaf_mask_;
+};
 
 layout (push_constant) uniform PushConstants {
     uint64_t elapsed_ms;
@@ -12,6 +21,7 @@ layout(set = 0, binding = 0, rgba8) uniform image2D output_image;
 // Set 1 is swapped out per scene.
 layout(set = 1, binding = 0) uniform accelerationStructureEXT tlas;
 layout(set = 1, binding = 1, rgba8) uniform readonly image3D volumes[];
+layout(set = 1, binding = 2) buffer SVOBuffer { SVONode nodes[]; } svo_buffers[];
 
 // Set 2 is not swapped out - it is for GraphicsContext-wide data.
 #define MAX_NUM_CHUNKS_LOADED_PER_FRAME 32

--- a/shaders/common.glsl
+++ b/shaders/common.glsl
@@ -9,6 +9,15 @@ struct SVONode {
     uint32_t child_pointer_;
     uint8_t valid_mask_;
     uint8_t leaf_mask_;
+    uint8_t _padding_[2];
+};
+
+struct SVOLeaf_Color {
+    uint8_t red_;
+    uint8_t green_;
+    uint8_t blue_;
+    uint8_t alpha_;
+    uint8_t _padding_[4];
 };
 
 layout (push_constant) uniform PushConstants {
@@ -21,7 +30,14 @@ layout(set = 0, binding = 0, rgba8) uniform image2D output_image;
 // Set 1 is swapped out per scene.
 layout(set = 1, binding = 0) uniform accelerationStructureEXT tlas;
 layout(set = 1, binding = 1, rgba8) uniform readonly image3D volumes[];
-layout(set = 1, binding = 2) buffer SVOBuffer { SVONode nodes[]; } svo_buffers[];
+layout(set = 1, binding = 2) buffer SVOBuffer {
+    uint32_t voxel_width;
+    uint32_t voxel_height;
+    uint32_t voxel_depth;
+    uint32_t num_nodes;
+    SVONode nodes[];
+} svo_buffers[];
+layout(set = 1, binding = 2) buffer SVOBuffer_Color { SVOLeaf_Color nodes[]; } svo_leaf_color_buffers[];
 
 // Set 2 is not swapped out - it is for GraphicsContext-wide data.
 #define MAX_NUM_CHUNKS_LOADED_PER_FRAME 32

--- a/shaders/rgen.glsl
+++ b/shaders/rgen.glsl
@@ -8,7 +8,7 @@
 layout(location = 0) rayPayloadEXT vec4 hit;
 
 void main() {
-    float t = float(elapsed_ms) / 1000.0;
+    float t = float(elapsed_ms) / 5000.0;
 
     vec2 normalized = vec2(gl_LaunchIDEXT.xy) / vec2(gl_LaunchSizeEXT.xy) - 0.5;
     vec3 ray_origin = 3.0 * vec3(cos(t), 0.0, sin(t));

--- a/shaders/rgen.glsl
+++ b/shaders/rgen.glsl
@@ -8,7 +8,7 @@
 layout(location = 0) rayPayloadEXT vec4 hit;
 
 void main() {
-    float t = float(elapsed_ms) / 5000.0;
+    float t = float(elapsed_ms) / 1000.0;
 
     vec2 normalized = vec2(gl_LaunchIDEXT.xy) / vec2(gl_LaunchSizeEXT.xy) - 0.5;
     vec3 ray_origin = 3.0 * vec3(cos(t), 0.0, sin(t));

--- a/voxels/CMakeLists.txt
+++ b/voxels/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 
-add_library(voxels Voxel.cpp VoxelChunkGeneration.cpp)
+add_library(voxels Voxel.cpp VoxelChunkGeneration.cpp Conversion.cpp)
 
 target_include_directories(voxels PUBLIC ${CMAKE_SOURCE_DIR})
 target_link_libraries(voxels PRIVATE graphics)

--- a/voxels/Conversion.cpp
+++ b/voxels/Conversion.cpp
@@ -73,7 +73,7 @@ std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw,
         uint32_t d = num_queues - 1;
         while (d > 0 && queues.at(d).size() == queue_size) {
             SVONode node{};
-            node.child_pointer_ = svo.size();
+            node.child_pointer_ = static_cast<uint32_t>((svo.size() - sizeof(uint32_t) * 4) / sizeof(SVONode));
             node.valid_mask_ = 0;
             node.leaf_mask_ = 0;
 
@@ -159,15 +159,16 @@ static void debug_print_internal_helper(const std::span<const std::byte> &svo,
     std::cout << " " << node.child_pointer_ << "\n";
 
     for (uint32_t i = 0, j = 0; i < 8; ++i) {
+	uint32_t adjusted_child_pointer = node.child_pointer_ * sizeof(SVONode) + sizeof(uint32_t) * 4;
         if (node.valid_mask_ & (1 << (7 - i)) &&
             node.leaf_mask_ & (1 << (7 - i))) {
             debug_print_leaf_helper(svo.subspan(0, j++ * sizeof(SVONode) +
-                                                       node.child_pointer_ +
+                                                       adjusted_child_pointer +
                                                        sizeof(SVONode)),
                                     bytes_per_voxel, level + 1);
         } else if (node.valid_mask_ & (1 << (7 - i))) {
             debug_print_internal_helper(svo.subspan(0, j++ * sizeof(SVONode) +
-                                                           node.child_pointer_ +
+                                                           adjusted_child_pointer +
                                                            sizeof(SVONode)),
                                         bytes_per_voxel, level + 1);
         }

--- a/voxels/Conversion.cpp
+++ b/voxels/Conversion.cpp
@@ -1,0 +1,70 @@
+#include <cstring>
+
+#include <external/libmorton/include/libmorton/morton.h>
+
+#include "Conversion.h"
+#include "utils/Assert.h"
+
+std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw, uint32_t width, uint32_t height, uint32_t depth, uint32_t bytes_per_voxel) {
+    struct SVONode {
+	uint32_t child_pointer_;
+	uint32_t valid_mask_: 8;
+	uint32_t leaf_mask_: 8;
+    };
+    static_assert(sizeof(SVONode) == 8);
+    ASSERT(bytes_per_voxel <= sizeof(SVONode), "Can't convert a raw chunk to an SVO chunk whose voxels take up more space than a parent SVO node.");
+    const SVONode EMPTY_SVO_NODE = [](){ SVONode node; memset(&node, 0, sizeof(SVONode)); return node; }();
+    auto nodes_equal = [&](const SVONode &a, const SVONode &b){ return memcmp(&a, &b, sizeof(SVONode)) == 0; };
+    auto is_node_empty = [&](const SVONode &node){ return nodes_equal(node, EMPTY_SVO_NODE); };
+    
+    const double power_of_two = log2(static_cast<double>(width));
+    ASSERT(width == height && height == depth && power_of_two == round(power_of_two), "Can't convert a raw chunk to an SVO chunk if it's not a power of two cube.");
+
+    const uint32_t queue_size = 8;
+    const uint32_t num_queues = static_cast<uint32_t>(power_of_two);
+    std::vector<std::vector<SVONode>> queues(num_queues);
+    for (auto &queue : queues) {
+	queue.reserve(queue_size);
+    }
+
+    std::vector<std::byte> svo;
+    auto push_node_to_svo = [&](SVONode node) {
+	for (uint32_t i = 0; i < sizeof(SVONode); ++i) {
+	    svo.emplace_back();
+	}
+	memcpy(&svo.back() - sizeof(SVONode) + 1, &node, sizeof(SVONode));
+    };
+    
+    const uint64_t num_voxels = width * height * depth;
+    for (uint64_t morton = 0; morton < num_voxels; ++morton) {
+	uint_fast32_t x = 0, y = 0, z = 0;
+	libmorton::morton3D_64_decode(morton, x, y, z);
+	size_t voxel_offset = (x + y * width + z * width * height) * bytes_per_voxel;
+
+	SVONode node {};
+	memcpy(&node, &raw[voxel_offset], bytes_per_voxel);
+
+	queues.at(num_queues - 1).push_back(node);
+	uint32_t d = num_queues - 1;
+	while (d > 0 && queues.at(d).size() == queue_size) {
+	    SVONode node {};
+	    node.child_pointer_ = svo.size() / sizeof(SVONode);
+	    node.valid_mask_ = 0;
+	    node.leaf_mask_ = 0;
+
+	    for (uint32_t i = 0; i < queue_size;  ++i) {
+		const SVONode &child = queues.at(d).at(i);
+		if (!is_node_empty(child)) {
+		    node.valid_mask_ |= 1 << (7 - i);
+		    push_node_to_svo(child);
+		}
+	    }
+
+	    queues.at(d).clear();
+	    queues.at(d - 1).push_back(node);
+	    --d;
+	}
+    }
+
+    return svo;
+}

--- a/voxels/Conversion.cpp
+++ b/voxels/Conversion.cpp
@@ -52,17 +52,16 @@ std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw, uin
 	    node.valid_mask_ = 0;
 	    node.leaf_mask_ = 0;
 
-	    bool identical_leaves = false;
+	    bool identical = false;
 	    for (uint32_t i = 0; i < queue_size;  ++i) {
 		node.valid_mask_ |= !is_node_empty(queues.at(d).at(i).first) << (7 - i);
 		node.leaf_mask_ |= queues.at(d).at(i).second << (7 - i);
-		bool identical_leaves = identical_leaves && nodes_equal(queues.at(d).at(i), queues.at(d).at(0));
+		bool identical = identical && nodes_equal(queues.at(d).at(i).first, queues.at(d).at(0).first);
 	    }
 	    node.leaf_mask_ &= node.valid_mask_;
-	    identical_leaves = identical_leaves && node.leaf_mask_ == 0xFF;
 
-	    if (identical_leaves) {
-		node = queues.at(d).at(0);
+	    if (identical) {
+		node = queues.at(d).at(0).first;
 	    } else {
 		for (uint32_t i = 0; i < queue_size;  ++i) {
 		    const SVONode &child = queues.at(d).at(i).first;
@@ -72,7 +71,7 @@ std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw, uin
 		}
 	    }
 
-	    queues.at(d - 1).emplace_back(node, identical_leaves);
+	    queues.at(d - 1).emplace_back(node, identical ? queues.at(d).at(0).second : false);
 	    queues.at(d).clear();
 	    --d;
 	}

--- a/voxels/Conversion.cpp
+++ b/voxels/Conversion.cpp
@@ -73,7 +73,8 @@ std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw,
         uint32_t d = num_queues - 1;
         while (d > 0 && queues.at(d).size() == queue_size) {
             SVONode node{};
-            node.child_pointer_ = static_cast<uint32_t>((svo.size() - sizeof(uint32_t) * 4) / sizeof(SVONode));
+            node.child_pointer_ = static_cast<uint32_t>(
+                (svo.size() - sizeof(uint32_t) * 4) / sizeof(SVONode));
             node.valid_mask_ = 0;
             node.leaf_mask_ = 0;
 
@@ -158,7 +159,8 @@ static void debug_print_internal_helper(const std::span<const std::byte> &svo,
     }
     std::cout << " " << node.child_pointer_ << "\n";
 
-    uint32_t adjusted_child_pointer = node.child_pointer_ * sizeof(SVONode) + sizeof(uint32_t) * 4;
+    uint32_t adjusted_child_pointer =
+        node.child_pointer_ * sizeof(SVONode) + sizeof(uint32_t) * 4;
     for (uint32_t i = 0, j = 0; i < 8; ++i) {
         if (node.valid_mask_ & (1 << (7 - i)) &&
             node.leaf_mask_ & (1 << (7 - i))) {
@@ -167,10 +169,10 @@ static void debug_print_internal_helper(const std::span<const std::byte> &svo,
                                                        sizeof(SVONode)),
                                     bytes_per_voxel, level + 1);
         } else if (node.valid_mask_ & (1 << (7 - i))) {
-            debug_print_internal_helper(svo.subspan(0, j++ * sizeof(SVONode) +
-                                                           adjusted_child_pointer +
-                                                           sizeof(SVONode)),
-                                        bytes_per_voxel, level + 1);
+            debug_print_internal_helper(
+                svo.subspan(0, j++ * sizeof(SVONode) + adjusted_child_pointer +
+                                   sizeof(SVONode)),
+                bytes_per_voxel, level + 1);
         }
     }
 }

--- a/voxels/Conversion.cpp
+++ b/voxels/Conversion.cpp
@@ -5,12 +5,13 @@
 #include "Conversion.h"
 #include "utils/Assert.h"
 
+struct SVONode {
+    uint32_t child_pointer_;
+    uint32_t valid_mask_: 8;
+    uint32_t leaf_mask_: 8;
+};
+
 std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw, uint32_t width, uint32_t height, uint32_t depth, uint32_t bytes_per_voxel) {
-    struct SVONode {
-	uint32_t child_pointer_;
-	uint32_t valid_mask_: 8;
-	uint32_t leaf_mask_: 8;
-    };
     static_assert(sizeof(SVONode) == 8);
     ASSERT(bytes_per_voxel <= sizeof(SVONode), "Can't convert a raw chunk to an SVO chunk whose voxels take up more space than a parent SVO node.");
     const SVONode EMPTY_SVO_NODE = [](){ SVONode node; memset(&node, 0, sizeof(SVONode)); return node; }();
@@ -21,13 +22,20 @@ std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw, uin
     ASSERT(width == height && height == depth && power_of_two == round(power_of_two), "Can't convert a raw chunk to an SVO chunk if it's not a power of two cube.");
 
     const uint32_t queue_size = 8;
-    const uint32_t num_queues = static_cast<uint32_t>(power_of_two);
+    const uint32_t num_queues = static_cast<uint32_t>(power_of_two) + 1;
     std::vector<std::vector<std::pair<SVONode, bool>>> queues(num_queues);
     for (auto &queue : queues) {
 	queue.reserve(queue_size);
     }
 
     std::vector<std::byte> svo;
+    for (uint32_t i = 0; i < sizeof(uint32_t) * 4; ++i) {
+	svo.emplace_back();
+    }
+    memcpy(&svo.at(0), &width, sizeof(uint32_t));
+    memcpy(&svo.at(sizeof(uint32_t)), &height, sizeof(uint32_t));
+    memcpy(&svo.at(sizeof(uint32_t) * 2), &depth, sizeof(uint32_t));
+
     auto push_node_to_svo = [&](SVONode node) {
 	for (uint32_t i = 0; i < sizeof(SVONode); ++i) {
 	    svo.emplace_back();
@@ -48,15 +56,15 @@ std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw, uin
 	uint32_t d = num_queues - 1;
 	while (d > 0 && queues.at(d).size() == queue_size) {
 	    SVONode node {};
-	    node.child_pointer_ = svo.size() / sizeof(SVONode);
+	    node.child_pointer_ = svo.size();
 	    node.valid_mask_ = 0;
 	    node.leaf_mask_ = 0;
 
-	    bool identical = false;
+	    bool identical = true;
 	    for (uint32_t i = 0; i < queue_size;  ++i) {
 		node.valid_mask_ |= !is_node_empty(queues.at(d).at(i).first) << (7 - i);
 		node.leaf_mask_ |= queues.at(d).at(i).second << (7 - i);
-		bool identical = identical && nodes_equal(queues.at(d).at(i).first, queues.at(d).at(0).first);
+		identical = identical && nodes_equal(queues.at(d).at(i).first, queues.at(d).at(0).first) && queues.at(d).at(i).second == queues.at(d).at(0).second;
 	    }
 	    node.leaf_mask_ &= node.valid_mask_;
 
@@ -76,6 +84,70 @@ std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw, uin
 	    --d;
 	}
     }
+    push_node_to_svo(queues.at(0).at(0).first);
+
+    const uint32_t num_nodes = static_cast<uint32_t>((svo.size() - sizeof(uint32_t) * 4) / sizeof(SVONode));
+    memcpy(&svo.at(sizeof(uint32_t) * 3), &num_nodes, sizeof(uint32_t));
 
     return svo;
+}
+
+static void debug_print_leaf_helper(const std::span<const std::byte> &svo, uint32_t bytes_per_voxel, uint32_t level) {
+    for (uint32_t i = 0; i < level; ++i) {
+	std::cout << " ";
+    }
+    
+    std::cout << "Leaf Node:";
+    for (size_t i = svo.size() - sizeof(SVONode); i < svo.size() - sizeof(SVONode) + bytes_per_voxel; ++i) {
+	uint32_t conv = std::to_integer<uint32_t>(svo[i]);
+	std::cout << " " << conv;
+    }
+    std::cout << "\n";
+}
+
+static void debug_print_internal_helper(const std::span<const std::byte> &svo, uint32_t bytes_per_voxel, uint32_t level) {
+    for (uint32_t i = 0; i < level; ++i) {
+	std::cout << " ";
+    }
+    
+    SVONode node;
+    memcpy(&node, svo.data() + svo.size() - sizeof(SVONode), sizeof(SVONode));
+    std::cout << "Internal Node: ";
+    for (uint32_t i = 0; i < 8; ++i) {
+	if (node.valid_mask_ & (1 << (7 - i))) {
+	    std::cout << "1";
+	} else {
+	    std::cout << "0";
+	}
+    }
+    std::cout << " ";
+    for (uint32_t i = 0; i < 8; ++i) {
+	if (node.leaf_mask_ & (1 << (7 - i))) {
+	    std::cout << "1";
+	} else {
+	    std::cout << "0";
+	}
+    }
+    std::cout << " " << node.child_pointer_ << "\n";
+
+    for (uint32_t i = 0, j = 0; i < 8; ++i) {
+	if (node.valid_mask_ & (1 << (7 - i)) && node.leaf_mask_ & (1 << (7 - i))) {
+	    debug_print_leaf_helper(svo.subspan(0, j++ * sizeof(SVONode) + node.child_pointer_ + sizeof(SVONode)), bytes_per_voxel, level + 1);
+	} else if (node.valid_mask_ & (1 << (7 - i))) {
+	    debug_print_internal_helper(svo.subspan(0, j++ * sizeof(SVONode) + node.child_pointer_ + sizeof(SVONode)), bytes_per_voxel, level + 1);
+	}
+    }
+}
+
+void debug_print_svo(const std::vector<std::byte> &svo, uint32_t bytes_per_voxel) {
+    ASSERT(svo.size() >= sizeof(uint32_t) * 4 + sizeof(SVONode), "Can't debug print a malformed SVO.");
+    std::cout << "INFO: Debug printing a " << svo.size() << " byte SVO.\n";
+    uint32_t header[4];
+    memcpy(header, svo.data(), sizeof(header));
+    std::cout << "SVO represent a " << header[0] << " x " << header[1] << " x " << header[2] << " volume. Its self reported size is " << header[3] << " node(s).\n";
+    if (header[3] > 1) {
+	debug_print_internal_helper(std::span(svo), bytes_per_voxel, 0);
+    } else {
+	debug_print_leaf_helper(std::span(svo), bytes_per_voxel, 0);
+    }
 }

--- a/voxels/Conversion.cpp
+++ b/voxels/Conversion.cpp
@@ -7,147 +7,186 @@
 
 struct SVONode {
     uint32_t child_pointer_;
-    uint32_t valid_mask_: 8;
-    uint32_t leaf_mask_: 8;
+    uint32_t valid_mask_ : 8;
+    uint32_t leaf_mask_ : 8;
 };
 
-std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw, uint32_t width, uint32_t height, uint32_t depth, uint32_t bytes_per_voxel) {
+std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw,
+                                          uint32_t width, uint32_t height,
+                                          uint32_t depth,
+                                          uint32_t bytes_per_voxel) {
     static_assert(sizeof(SVONode) == 8);
-    ASSERT(bytes_per_voxel <= sizeof(SVONode), "Can't convert a raw chunk to an SVO chunk whose voxels take up more space than a parent SVO node.");
-    const SVONode EMPTY_SVO_NODE = [](){ SVONode node; memset(&node, 0, sizeof(SVONode)); return node; }();
-    auto nodes_equal = [&](const SVONode &a, const SVONode &b){ return memcmp(&a, &b, sizeof(SVONode)) == 0; };
-    auto is_node_empty = [&](const SVONode &node){ return nodes_equal(node, EMPTY_SVO_NODE); };
-    
+    ASSERT(bytes_per_voxel <= sizeof(SVONode),
+           "Can't convert a raw chunk to an SVO chunk whose voxels take up "
+           "more space than a parent SVO node.");
+    const SVONode EMPTY_SVO_NODE = []() {
+        SVONode node;
+        memset(&node, 0, sizeof(SVONode));
+        return node;
+    }();
+    auto nodes_equal = [&](const SVONode &a, const SVONode &b) {
+        return memcmp(&a, &b, sizeof(SVONode)) == 0;
+    };
+    auto is_node_empty = [&](const SVONode &node) {
+        return nodes_equal(node, EMPTY_SVO_NODE);
+    };
+
     const double power_of_two = log2(static_cast<double>(width));
-    ASSERT(width == height && height == depth && power_of_two == round(power_of_two), "Can't convert a raw chunk to an SVO chunk if it's not a power of two cube.");
+    ASSERT(width == height && height == depth &&
+               power_of_two == round(power_of_two),
+           "Can't convert a raw chunk to an SVO chunk if it's not a power of "
+           "two cube.");
 
     const uint32_t queue_size = 8;
     const uint32_t num_queues = static_cast<uint32_t>(power_of_two) + 1;
     std::vector<std::vector<std::pair<SVONode, bool>>> queues(num_queues);
     for (auto &queue : queues) {
-	queue.reserve(queue_size);
+        queue.reserve(queue_size);
     }
 
     std::vector<std::byte> svo;
     for (uint32_t i = 0; i < sizeof(uint32_t) * 4; ++i) {
-	svo.emplace_back();
+        svo.emplace_back();
     }
     memcpy(&svo.at(0), &width, sizeof(uint32_t));
     memcpy(&svo.at(sizeof(uint32_t)), &height, sizeof(uint32_t));
     memcpy(&svo.at(sizeof(uint32_t) * 2), &depth, sizeof(uint32_t));
 
     auto push_node_to_svo = [&](SVONode node) {
-	for (uint32_t i = 0; i < sizeof(SVONode); ++i) {
-	    svo.emplace_back();
-	}
-	memcpy(&svo.back() - sizeof(SVONode) + 1, &node, sizeof(SVONode));
+        for (uint32_t i = 0; i < sizeof(SVONode); ++i) {
+            svo.emplace_back();
+        }
+        memcpy(&svo.back() - sizeof(SVONode) + 1, &node, sizeof(SVONode));
     };
-    
+
     const uint64_t num_voxels = width * height * depth;
     for (uint64_t morton = 0; morton < num_voxels; ++morton) {
-	uint_fast32_t x = 0, y = 0, z = 0;
-	libmorton::morton3D_64_decode(morton, x, y, z);
-	size_t voxel_offset = (x + y * width + z * width * height) * bytes_per_voxel;
+        uint_fast32_t x = 0, y = 0, z = 0;
+        libmorton::morton3D_64_decode(morton, x, y, z);
+        size_t voxel_offset =
+            (x + y * width + z * width * height) * bytes_per_voxel;
 
-	SVONode node {};
-	memcpy(&node, &raw[voxel_offset], bytes_per_voxel);
+        SVONode node{};
+        memcpy(&node, &raw[voxel_offset], bytes_per_voxel);
 
-	queues.at(num_queues - 1).emplace_back(node, true);
-	uint32_t d = num_queues - 1;
-	while (d > 0 && queues.at(d).size() == queue_size) {
-	    SVONode node {};
-	    node.child_pointer_ = svo.size();
-	    node.valid_mask_ = 0;
-	    node.leaf_mask_ = 0;
+        queues.at(num_queues - 1).emplace_back(node, true);
+        uint32_t d = num_queues - 1;
+        while (d > 0 && queues.at(d).size() == queue_size) {
+            SVONode node{};
+            node.child_pointer_ = svo.size();
+            node.valid_mask_ = 0;
+            node.leaf_mask_ = 0;
 
-	    bool identical = true;
-	    for (uint32_t i = 0; i < queue_size;  ++i) {
-		node.valid_mask_ |= !is_node_empty(queues.at(d).at(i).first) << (7 - i);
-		node.leaf_mask_ |= queues.at(d).at(i).second << (7 - i);
-		identical = identical && nodes_equal(queues.at(d).at(i).first, queues.at(d).at(0).first) && queues.at(d).at(i).second == queues.at(d).at(0).second;
-	    }
-	    node.leaf_mask_ &= node.valid_mask_;
+            bool identical = true;
+            for (uint32_t i = 0; i < queue_size; ++i) {
+                node.valid_mask_ |= !is_node_empty(queues.at(d).at(i).first)
+                                    << (7 - i);
+                node.leaf_mask_ |= queues.at(d).at(i).second << (7 - i);
+                identical =
+                    identical &&
+                    nodes_equal(queues.at(d).at(i).first,
+                                queues.at(d).at(0).first) &&
+                    queues.at(d).at(i).second == queues.at(d).at(0).second;
+            }
+            node.leaf_mask_ &= node.valid_mask_;
 
-	    if (identical) {
-		node = queues.at(d).at(0).first;
-	    } else {
-		for (uint32_t i = 0; i < queue_size;  ++i) {
-		    const SVONode &child = queues.at(d).at(i).first;
-		    if (!is_node_empty(child)) {
-			push_node_to_svo(child);
-		    }
-		}
-	    }
+            if (identical) {
+                node = queues.at(d).at(0).first;
+            } else {
+                for (uint32_t i = 0; i < queue_size; ++i) {
+                    const SVONode &child = queues.at(d).at(i).first;
+                    if (!is_node_empty(child)) {
+                        push_node_to_svo(child);
+                    }
+                }
+            }
 
-	    queues.at(d - 1).emplace_back(node, identical ? queues.at(d).at(0).second : false);
-	    queues.at(d).clear();
-	    --d;
-	}
+            queues.at(d - 1).emplace_back(
+                node, identical ? queues.at(d).at(0).second : false);
+            queues.at(d).clear();
+            --d;
+        }
     }
     push_node_to_svo(queues.at(0).at(0).first);
 
-    const uint32_t num_nodes = static_cast<uint32_t>((svo.size() - sizeof(uint32_t) * 4) / sizeof(SVONode));
+    const uint32_t num_nodes = static_cast<uint32_t>(
+        (svo.size() - sizeof(uint32_t) * 4) / sizeof(SVONode));
     memcpy(&svo.at(sizeof(uint32_t) * 3), &num_nodes, sizeof(uint32_t));
 
     return svo;
 }
 
-static void debug_print_leaf_helper(const std::span<const std::byte> &svo, uint32_t bytes_per_voxel, uint32_t level) {
+static void debug_print_leaf_helper(const std::span<const std::byte> &svo,
+                                    uint32_t bytes_per_voxel, uint32_t level) {
     for (uint32_t i = 0; i < level; ++i) {
-	std::cout << " ";
+        std::cout << " ";
     }
-    
+
     std::cout << "Leaf Node:";
-    for (size_t i = svo.size() - sizeof(SVONode); i < svo.size() - sizeof(SVONode) + bytes_per_voxel; ++i) {
-	uint32_t conv = std::to_integer<uint32_t>(svo[i]);
-	std::cout << " " << conv;
+    for (size_t i = svo.size() - sizeof(SVONode);
+         i < svo.size() - sizeof(SVONode) + bytes_per_voxel; ++i) {
+        uint32_t conv = std::to_integer<uint32_t>(svo[i]);
+        std::cout << " " << conv;
     }
     std::cout << "\n";
 }
 
-static void debug_print_internal_helper(const std::span<const std::byte> &svo, uint32_t bytes_per_voxel, uint32_t level) {
+static void debug_print_internal_helper(const std::span<const std::byte> &svo,
+                                        uint32_t bytes_per_voxel,
+                                        uint32_t level) {
     for (uint32_t i = 0; i < level; ++i) {
-	std::cout << " ";
+        std::cout << " ";
     }
-    
+
     SVONode node;
     memcpy(&node, svo.data() + svo.size() - sizeof(SVONode), sizeof(SVONode));
     std::cout << "Internal Node: ";
     for (uint32_t i = 0; i < 8; ++i) {
-	if (node.valid_mask_ & (1 << (7 - i))) {
-	    std::cout << "1";
-	} else {
-	    std::cout << "0";
-	}
+        if (node.valid_mask_ & (1 << (7 - i))) {
+            std::cout << "1";
+        } else {
+            std::cout << "0";
+        }
     }
     std::cout << " ";
     for (uint32_t i = 0; i < 8; ++i) {
-	if (node.leaf_mask_ & (1 << (7 - i))) {
-	    std::cout << "1";
-	} else {
-	    std::cout << "0";
-	}
+        if (node.leaf_mask_ & (1 << (7 - i))) {
+            std::cout << "1";
+        } else {
+            std::cout << "0";
+        }
     }
     std::cout << " " << node.child_pointer_ << "\n";
 
     for (uint32_t i = 0, j = 0; i < 8; ++i) {
-	if (node.valid_mask_ & (1 << (7 - i)) && node.leaf_mask_ & (1 << (7 - i))) {
-	    debug_print_leaf_helper(svo.subspan(0, j++ * sizeof(SVONode) + node.child_pointer_ + sizeof(SVONode)), bytes_per_voxel, level + 1);
-	} else if (node.valid_mask_ & (1 << (7 - i))) {
-	    debug_print_internal_helper(svo.subspan(0, j++ * sizeof(SVONode) + node.child_pointer_ + sizeof(SVONode)), bytes_per_voxel, level + 1);
-	}
+        if (node.valid_mask_ & (1 << (7 - i)) &&
+            node.leaf_mask_ & (1 << (7 - i))) {
+            debug_print_leaf_helper(svo.subspan(0, j++ * sizeof(SVONode) +
+                                                       node.child_pointer_ +
+                                                       sizeof(SVONode)),
+                                    bytes_per_voxel, level + 1);
+        } else if (node.valid_mask_ & (1 << (7 - i))) {
+            debug_print_internal_helper(svo.subspan(0, j++ * sizeof(SVONode) +
+                                                           node.child_pointer_ +
+                                                           sizeof(SVONode)),
+                                        bytes_per_voxel, level + 1);
+        }
     }
 }
 
-void debug_print_svo(const std::vector<std::byte> &svo, uint32_t bytes_per_voxel) {
-    ASSERT(svo.size() >= sizeof(uint32_t) * 4 + sizeof(SVONode), "Can't debug print a malformed SVO.");
+void debug_print_svo(const std::vector<std::byte> &svo,
+                     uint32_t bytes_per_voxel) {
+    ASSERT(svo.size() >= sizeof(uint32_t) * 4 + sizeof(SVONode),
+           "Can't debug print a malformed SVO.");
     std::cout << "INFO: Debug printing a " << svo.size() << " byte SVO.\n";
     uint32_t header[4];
     memcpy(header, svo.data(), sizeof(header));
-    std::cout << "SVO represent a " << header[0] << " x " << header[1] << " x " << header[2] << " volume. Its self reported size is " << header[3] << " node(s).\n";
+    std::cout << "SVO represent a " << header[0] << " x " << header[1] << " x "
+              << header[2] << " volume. Its self reported size is " << header[3]
+              << " node(s).\n";
     if (header[3] > 1) {
-	debug_print_internal_helper(std::span(svo), bytes_per_voxel, 0);
+        debug_print_internal_helper(std::span(svo), bytes_per_voxel, 0);
     } else {
-	debug_print_leaf_helper(std::span(svo), bytes_per_voxel, 0);
+        debug_print_leaf_helper(std::span(svo), bytes_per_voxel, 0);
     }
 }

--- a/voxels/Conversion.cpp
+++ b/voxels/Conversion.cpp
@@ -158,8 +158,8 @@ static void debug_print_internal_helper(const std::span<const std::byte> &svo,
     }
     std::cout << " " << node.child_pointer_ << "\n";
 
+    uint32_t adjusted_child_pointer = node.child_pointer_ * sizeof(SVONode) + sizeof(uint32_t) * 4;
     for (uint32_t i = 0, j = 0; i < 8; ++i) {
-	uint32_t adjusted_child_pointer = node.child_pointer_ * sizeof(SVONode) + sizeof(uint32_t) * 4;
         if (node.valid_mask_ & (1 << (7 - i)) &&
             node.leaf_mask_ & (1 << (7 - i))) {
             debug_print_leaf_helper(svo.subspan(0, j++ * sizeof(SVONode) +

--- a/voxels/Conversion.h
+++ b/voxels/Conversion.h
@@ -3,3 +3,5 @@
 #include "Voxel.h"
 
 std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw, uint32_t width, uint32_t height, uint32_t depth, uint32_t bytes_per_voxel);
+
+void debug_print_svo(const std::vector<std::byte> &svo, uint32_t bytes_per_voxel);

--- a/voxels/Conversion.h
+++ b/voxels/Conversion.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "Voxel.h"
+
+std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw, uint32_t width, uint32_t height, uint32_t depth, uint32_t bytes_per_voxel);

--- a/voxels/Conversion.h
+++ b/voxels/Conversion.h
@@ -2,6 +2,10 @@
 
 #include "Voxel.h"
 
-std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw, uint32_t width, uint32_t height, uint32_t depth, uint32_t bytes_per_voxel);
+std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw,
+                                          uint32_t width, uint32_t height,
+                                          uint32_t depth,
+                                          uint32_t bytes_per_voxel);
 
-void debug_print_svo(const std::vector<std::byte> &svo, uint32_t bytes_per_voxel);
+void debug_print_svo(const std::vector<std::byte> &svo,
+                     uint32_t bytes_per_voxel);

--- a/voxels/Voxel.cpp
+++ b/voxels/Voxel.cpp
@@ -62,6 +62,11 @@ void VoxelChunk::queue_gpu_upload(std::shared_ptr<Device> device,
                                     get_cpu_data(), {timeline_}, {timeline_});
         break;
     }
+    case Format::SVO: {
+	buffer_data_ = std::make_shared<GPUBuffer>(allocator, get_cpu_data().size(), 8, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, 0);
+	ring_buffer->copy_to_device(buffer_data_, 0, get_cpu_data(), {timeline_}, {timeline_});
+	break;
+    }
     default: {
         ASSERT(false, "GPU upload for format is unimplemented.");
     }

--- a/voxels/Voxel.cpp
+++ b/voxels/Voxel.cpp
@@ -15,6 +15,12 @@ std::span<const std::byte> VoxelChunk::get_cpu_data() const {
     return std::span{cpu_data_};
 }
 
+std::shared_ptr<GPUBuffer> VoxelChunk::get_gpu_buffer() const {
+    ASSERT(state_ == State::GPU, "Tried to get GPU buffer data of voxel chunk "
+                                 "without GPU data resident.");
+    return buffer_data_;
+}
+
 std::shared_ptr<GPUVolume> VoxelChunk::get_gpu_volume() const {
     ASSERT(state_ == State::GPU, "Tried to get GPU volume data of voxel chunk "
                                  "without GPU data resident.");
@@ -63,9 +69,14 @@ void VoxelChunk::queue_gpu_upload(std::shared_ptr<Device> device,
         break;
     }
     case Format::SVO: {
-	buffer_data_ = std::make_shared<GPUBuffer>(allocator, get_cpu_data().size(), 8, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, 0);
-	ring_buffer->copy_to_device(buffer_data_, 0, get_cpu_data(), {timeline_}, {timeline_});
-	break;
+        buffer_data_ =
+            std::make_shared<GPUBuffer>(allocator, get_cpu_data().size(), 8,
+                                        VK_BUFFER_USAGE_TRANSFER_DST_BIT |
+                                            VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+                                        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, 0);
+        ring_buffer->copy_to_device(buffer_data_, 0, get_cpu_data(),
+                                    {timeline_}, {timeline_});
+        break;
     }
     default: {
         ASSERT(false, "GPU upload for format is unimplemented.");

--- a/voxels/Voxel.h
+++ b/voxels/Voxel.h
@@ -21,6 +21,7 @@ class VoxelChunk {
 
     enum class Format {
         Raw,
+	SVO,
     };
 
     enum class AttributeSet {
@@ -47,6 +48,7 @@ class VoxelChunk {
 
   private:
     std::vector<std::byte> cpu_data_;
+    std::shared_ptr<GPUBuffer> buffer_data_;
     std::shared_ptr<GPUVolume> volume_data_;
     std::shared_ptr<Semaphore> timeline_ = nullptr;
     uint32_t width_;

--- a/voxels/Voxel.h
+++ b/voxels/Voxel.h
@@ -21,7 +21,7 @@ class VoxelChunk {
 
     enum class Format {
         Raw,
-	SVO,
+        SVO,
     };
 
     enum class AttributeSet {
@@ -34,6 +34,7 @@ class VoxelChunk {
                AttributeSet attribute_set);
 
     std::span<const std::byte> get_cpu_data() const;
+    std::shared_ptr<GPUBuffer> get_gpu_buffer() const;
     std::shared_ptr<GPUVolume> get_gpu_volume() const;
     std::shared_ptr<Semaphore> get_timeline() const;
     uint32_t get_width() const;

--- a/voxels/VoxelChunkGeneration.cpp
+++ b/voxels/VoxelChunkGeneration.cpp
@@ -79,13 +79,9 @@ std::vector<std::byte> generate_basic_procedural_chunk(uint32_t width,
         for (uint32_t y = 0; y < height; ++y) {
             for (uint32_t z = 0; z < depth; ++z) {
                 if (densityfunction_({x, y, z}) > -30.0) {
-                    //std::byte red = static_cast<std::byte>(x * 15);
-                    //std::byte green = static_cast<std::byte>(y * 15);
-                    //std::byte blue = static_cast<std::byte>(z * 15);
-                    //std::byte alpha = static_cast<std::byte>(255);
-                    std::byte red = static_cast<std::byte>(255);
-                    std::byte green = static_cast<std::byte>(255);
-                    std::byte blue = static_cast<std::byte>(255);
+                    std::byte red = static_cast<std::byte>(x * 15);
+                    std::byte green = static_cast<std::byte>(y * 15);
+                    std::byte blue = static_cast<std::byte>(z * 15);
                     std::byte alpha = static_cast<std::byte>(255);
 
                     size_t voxel_idx = x + y * width + z * width * height;

--- a/voxels/VoxelChunkGeneration.cpp
+++ b/voxels/VoxelChunkGeneration.cpp
@@ -79,9 +79,13 @@ std::vector<std::byte> generate_basic_procedural_chunk(uint32_t width,
         for (uint32_t y = 0; y < height; ++y) {
             for (uint32_t z = 0; z < depth; ++z) {
                 if (densityfunction_({x, y, z}) > -30.0) {
-                    std::byte red = static_cast<std::byte>(x * 15);
-                    std::byte green = static_cast<std::byte>(y * 15);
-                    std::byte blue = static_cast<std::byte>(z * 15);
+                    //std::byte red = static_cast<std::byte>(x * 15);
+                    //std::byte green = static_cast<std::byte>(y * 15);
+                    //std::byte blue = static_cast<std::byte>(z * 15);
+                    //std::byte alpha = static_cast<std::byte>(255);
+                    std::byte red = static_cast<std::byte>(255);
+                    std::byte green = static_cast<std::byte>(255);
+                    std::byte blue = static_cast<std::byte>(255);
                     std::byte alpha = static_cast<std::byte>(255);
 
                     size_t voxel_idx = x + y * width + z * width * height;

--- a/voxels/VoxelChunkGeneration.cpp
+++ b/voxels/VoxelChunkGeneration.cpp
@@ -1,12 +1,12 @@
+#include <cmath>
 #include <filesystem>
 #include <fstream>
+#include <random>
 #include <stdio.h>
 #include <string>
-#include <random>
-#include <cmath>
 
-#include <external/glm/glm/glm.hpp>
 #include <external/PerlinNoise.hpp>
+#include <external/glm/glm/glm.hpp>
 #include <external/ogt_vox.h>
 
 #include "VoxelChunkGeneration.h"
@@ -133,12 +133,14 @@ std::vector<std::byte> generate_terrain(uint32_t width, uint32_t height,
 
 std::vector<std::vector<std::byte>>
 load_vox_scene_as_models(std::string filepath) {
-    ASSERT(std::filesystem::exists(filepath), "Tried to load .vox scene from file that doesn't exist.");
+    ASSERT(std::filesystem::exists(filepath),
+           "Tried to load .vox scene from file that doesn't exist.");
     std::ifstream fstream(filepath, std::ios::in | std::ios::binary);
     std::vector<uint8_t> buffer(std::filesystem::file_size(filepath));
-    fstream.read(reinterpret_cast<char*>(buffer.data()), buffer.size());
+    fstream.read(reinterpret_cast<char *>(buffer.data()), buffer.size());
 
-    const ogt_vox_scene *scene = ogt_vox_read_scene(buffer.data(), buffer.size());
+    const ogt_vox_scene *scene =
+        ogt_vox_read_scene(buffer.data(), buffer.size());
 
     std::vector<std::vector<std::byte>> models;
 


### PR DESCRIPTION
- convert_raw_to_svo implements converting a raw voxel model to an SVO
- SVO_Color_rint.glsl and SVO_Color_rchit.glsl implement SVO rendering
- Rewrite drivers/ivs.cpp to use SVO format for demonstrative purposes

One thing I've noticed is that raw format tracing is actually faster for the models we've used so far. This is likely because our current models are relatively small (64^3 maximum) and have high variance amongst voxels. SVO will provide better tracing scalability for larger, more homogeneous models. SVO also already provides some compression over the raw format for certain models. For the radius 20 sphere, it compresses a 1048576 byte raw model to a 311192 byte SVO. For the procedural chunk, the compression is 16384 bytes -> 15120 bytes. For the radius 32 sphere, 1048576 bytes turn into 1267920 bytes. This is likely because the larger sphere is less homogeneous than the other models.