### PR TITLE
Add Emissive Voxels

### DIFF
--- a/drivers/ivs.cpp
+++ b/drivers/ivs.cpp
@@ -25,7 +25,17 @@ int main(int argc, char *argv[]) {
     glm::mat3x4 transform1 = {1.0F, 0.0F,   0.0F, -64.0F, 0.0F, 1.0F,
                               0.0F, -64.0F, 0.0F, 0.0F,   1.0F, -64.0F};
     auto object1 = build_object(context, model1, transform1);
-    auto scene = build_scene(context, {object1});
+
+    auto emissive_block = generate_basic_filled_chunk(8, 8, 8);
+    VoxelChunkPtr test_light = chunk_manager.add_chunk(
+        std::move(emissive_block), 8, 8, 8, VoxelChunk::Format::Raw,
+        VoxelChunk::AttributeSet::Emissive);
+    auto light = build_model(context, test_light);
+    glm::mat3x4 transform2 = {2.0F, 0.0F,   0.0F, 0.0F, 0.0F, 2.0F,
+                              0.0F, 0.0F, 0.0F, 0.0F,   2.0F, 0.0F};
+    auto object2 = build_object(context, light, transform2);
+
+    auto scene = build_scene(context, {object1, object2});
 
     double elapsed = 0.0;
     while (!window->should_close()) {

--- a/graphics/GraphicsContext.cpp
+++ b/graphics/GraphicsContext.cpp
@@ -56,6 +56,8 @@ class GraphicsContext {
     std::shared_ptr<GPUImage> blue_noise_ = nullptr;
 
     std::shared_ptr<GPUImage> image_history_ = nullptr;
+    std::shared_ptr<GPUImage> g_normals_ = nullptr;
+    std::shared_ptr<GPUImage> g_positions_ = nullptr;
 
     std::shared_ptr<DescriptorSet> wide_descriptor_ = nullptr;
 
@@ -178,7 +180,7 @@ GraphicsContext::GraphicsContext(std::shared_ptr<Window> window) {
 
     image_history_ = std::make_shared<GPUImage>(
         gpu_allocator_, swapchain_->get_extent(), swapchain_->get_format(), 0,
-        VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT,
+        VK_IMAGE_USAGE_STORAGE_BIT,
         VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
         VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT, 1, 1);
 
@@ -246,13 +248,13 @@ GraphicsContext::GraphicsContext(std::shared_ptr<Window> window) {
         DescriptorSetBuilder tonemap_builder(descriptor_allocator_);
         tonemap_builder.bind_image(0,
                                    {.sampler = VK_NULL_HANDLE,
-                                    .imageView = image_history_->get_view(),
+                                    .imageView = image_views[image_index],
                                     .imageLayout = VK_IMAGE_LAYOUT_GENERAL},
                                    VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
                                    VK_SHADER_STAGE_COMPUTE_BIT);
         tonemap_builder.bind_image(1,
                                    {.sampler = VK_NULL_HANDLE,
-                                    .imageView = image_views[image_index],
+                                    .imageView = image_history_->get_view(),
                                     .imageLayout = VK_IMAGE_LAYOUT_GENERAL},
                                    VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
                                    VK_SHADER_STAGE_COMPUTE_BIT);

--- a/graphics/GraphicsContext.cpp
+++ b/graphics/GraphicsContext.cpp
@@ -201,13 +201,13 @@ GraphicsContext::GraphicsContext(std::shared_ptr<Window> window) {
                              VK_SHADER_STAGE_RAYGEN_BIT_KHR);
     wide_builder.bind_image(2,
                             {.sampler = VK_NULL_HANDLE,
-                             .imageView = image_history_->get_view(),
+                             .imageView = blue_noise_->get_view(),
                              .imageLayout = VK_IMAGE_LAYOUT_GENERAL},
                             VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
                             VK_SHADER_STAGE_RAYGEN_BIT_KHR);
     wide_builder.bind_image(3,
                             {.sampler = VK_NULL_HANDLE,
-                             .imageView = blue_noise_->get_view(),
+                             .imageView = image_history_->get_view(),
                              .imageLayout = VK_IMAGE_LAYOUT_GENERAL},
                             VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
                             VK_SHADER_STAGE_RAYGEN_BIT_KHR);

--- a/graphics/GraphicsContext.cpp
+++ b/graphics/GraphicsContext.cpp
@@ -21,7 +21,8 @@ const std::map<std::pair<VoxelChunk::Format, VoxelChunk::AttributeSet>,
     FORMAT_TO_SBT_OFFSET = {
         {{VoxelChunk::Format::Raw, VoxelChunk::AttributeSet::Color}, 1},
         {{VoxelChunk::Format::SVO, VoxelChunk::AttributeSet::Color}, 2},
-};
+        {{VoxelChunk::Format::Raw, VoxelChunk::AttributeSet::Emissive}, 3}
+    };
 const uint64_t MAX_NUM_CHUNKS_LOADED_PER_FRAME = 32;
 
 class GraphicsContext {
@@ -218,12 +219,14 @@ GraphicsContext::GraphicsContext(std::shared_ptr<Window> window) {
     auto raw_color_rint = std::make_shared<Shader>(device_, "Raw_Color_rint");
     auto svo_color_rchit = std::make_shared<Shader>(device_, "SVO_Color_rchit");
     auto svo_color_rint = std::make_shared<Shader>(device_, "SVO_Color_rint");
+    auto emissive_rchit = std::make_shared<Shader>(device_, "Emissive_rchit");
     std::vector<std::vector<std::shared_ptr<Shader>>> shader_groups = {
         {rgen},
         {rmiss},
         {unloaded_rchit, unloaded_rint},
         {raw_color_rchit, raw_color_rint},
         {svo_color_rchit, svo_color_rint},
+        {emissive_rchit, raw_color_rint},
     };
     std::vector<VkDescriptorSetLayout> layouts = {
         swapchain_->get_image_descriptor(0)->get_layout(),

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -12,6 +12,7 @@ set(GLSL_SHADER_FILES
   Unloaded_rchit.glsl
   Unloaded_rint.glsl
   tonemap_comp.glsl
+  Emissive_rchit.glsl
 )
 
 foreach(FILE ${GLSL_SHADER_FILES})

--- a/shaders/Emissive_rchit.glsl
+++ b/shaders/Emissive_rchit.glsl
@@ -8,23 +8,21 @@
 
 layout(location = 0) rayPayloadInEXT RayPayload payload;
 
-hitAttributeEXT uint leaf_id;
-hitAttributeEXT uint voxel_normal_id;
-
 void main() {
-    uint svo_id = gl_InstanceCustomIndexEXT;
-    SVOLeaf_Color color = svo_leaf_color_buffers[svo_id].nodes[leaf_id];
+    uint volume_id = gl_InstanceCustomIndexEXT;
+
+    vec3 world_ray_pos = gl_WorldRayOriginEXT + gl_WorldRayDirectionEXT * gl_HitTEXT;
+    vec3 world_obj_pos = gl_ObjectToWorldEXT * vec4(0.0, 0.0, 0.0, 1.0);
+
+    vec3 voxel_sample_pos = gl_WorldToObjectEXT * vec4(world_ray_pos, 1.0);
+    ivec3 volume_load_pos = ivec3(voxel_sample_pos - 0.5 * voxel_normals[gl_HitKindEXT]);
+
     payload.hit = true;
-    payload.world_position = gl_WorldRayOriginEXT + gl_WorldRayDirectionEXT * gl_HitTEXT;
+    payload.world_position = world_ray_pos;
     payload.world_normal = gl_ObjectToWorldEXT * vec4(voxel_normals[gl_HitKindEXT], 0.0);
     payload.tangent = gl_ObjectToWorldEXT * vec4(voxel_tangents[gl_HitKindEXT], 0.0);
     payload.bitangent = gl_ObjectToWorldEXT * vec4(voxel_bitangents[gl_HitKindEXT], 0.0);
-    payload.color = vec4(
-	       float(int(color.red_)) / 255.0,
-	       float(int(color.green_)) / 255.0,
-	       float(int(color.blue_)) / 255.0,
-	       float(int(color.alpha_)) / 255.0
-	       );
+    payload.color = imageLoad(volumes[volume_id], volume_load_pos);
     payload.voxel_face = gl_HitKindEXT;
-    payload.emissive = false;
+    payload.emissive = true;
 }

--- a/shaders/Raw_Color_rchit.glsl
+++ b/shaders/Raw_Color_rchit.glsl
@@ -24,4 +24,5 @@ void main() {
     payload.bitangent = gl_ObjectToWorldEXT * vec4(voxel_bitangents[gl_HitKindEXT], 0.0);
     payload.color = imageLoad(volumes[volume_id], volume_load_pos);
     payload.voxel_face = gl_HitKindEXT;
+    payload.emissive = false;
 }

--- a/shaders/common.glsl
+++ b/shaders/common.glsl
@@ -74,6 +74,8 @@ layout(set = 2, binding = 1) uniform camera_ {
 layout(set = 2, binding = 2, rgba8) uniform image2D blue_noise;
 
 layout(set = 2, binding = 3, rgba8) uniform image2D image_history;
+layout(set = 2, binding = 4, rgba8) uniform image2D image_normals;
+layout(set = 2, binding = 5, rgba8) uniform image2D image_positions;
 
 
 const float FAR_AWAY = 1000.0;

--- a/shaders/common.glsl
+++ b/shaders/common.glsl
@@ -32,6 +32,7 @@ struct RayPayload {
     vec3 bitangent;
     uint voxel_face;
     bool hit;
+    bool emissive;
 };
 
 // Set 0 is swapped out per swapchain image.

--- a/shaders/common.glsl
+++ b/shaders/common.glsl
@@ -71,8 +71,9 @@ layout(set = 2, binding = 1) uniform camera_ {
 	Camera camera;
 };
 
-layout(set = 2, binding = 2, rgba8) uniform image2D image_history;
+layout(set = 2, binding = 2, rgba8) uniform image2D blue_noise;
 
-layout(set = 2, binding = 3, rgba8) uniform image2D blue_noise;
+layout(set = 2, binding = 3, rgba8) uniform image2D image_history;
+
 
 const float FAR_AWAY = 1000.0;

--- a/shaders/rgen.glsl
+++ b/shaders/rgen.glsl
@@ -45,6 +45,10 @@ void main() {
     for (bounce = 0; bounce < MAX_BOUNCES; bounce++) {
         traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xFF, 0, 0, 0, ray_origin, 0.001f, ray_direction, 10000.0f, 0);
 
+        if (payload.hit && payload.emissive) {
+            L += weight * payload.color.xyz; // if we hit a direct light
+        }
+
         // If we've hit something, we send another ray in a random direction.
         // Otherwise assume we hit the sky.
         // Note that this is **only** doing indirect lighting.

--- a/shaders/rgen.glsl
+++ b/shaders/rgen.glsl
@@ -39,10 +39,6 @@ void main() {
     ivec2 blue_noise_coords = ivec2((gl_LaunchIDEXT.xy + ivec2(hash(t), hash(3 * t))) % blue_noise_size);
     vec4 random = imageLoad(blue_noise, blue_noise_coords);
 
-    // Todo: is there a better way to clear these in a raytracing pipeline...?
-    imageStore(image_normals, ivec2(gl_LaunchIDEXT), vec4(0.0f));
-    imageStore(image_positions, ivec2(gl_LaunchIDEXT), vec4(0.0f));
-
     vec3 L = vec3(0.0f);
     vec3 weight = vec3(1.0f);
     int bounce = 0;

--- a/shaders/rgen.glsl
+++ b/shaders/rgen.glsl
@@ -77,11 +77,13 @@ void main() {
 
     vec4 final_radiance = vec4(L, 1.0f);
 
-    if (camera.frames_since_update == 0) {
-        imageStore(image_history, ivec2(gl_LaunchIDEXT), final_radiance);
-    } else {
-        vec4 history = imageLoad(image_history, ivec2(gl_LaunchIDEXT));
-        vec4 final_color = mix(history, final_radiance, 1.0f / (camera.frames_since_update + 1));
-        imageStore(image_history, ivec2(gl_LaunchIDEXT), final_color);
-    }
+    imageStore(image_history, ivec2(gl_LaunchIDEXT), final_radiance);
+
+    // if (camera.frames_since_update == 0) {
+    //     imageStore(image_history, ivec2(gl_LaunchIDEXT), final_radiance);
+    // } else {
+    //     vec4 history = imageLoad(image_history, ivec2(gl_LaunchIDEXT));
+    //     vec4 final_color = mix(history, final_radiance, 1.0f / (camera.frames_since_update + 1));
+    //     imageStore(image_history, ivec2(gl_LaunchIDEXT), final_color);
+    // }
 }

--- a/shaders/rmiss.glsl
+++ b/shaders/rmiss.glsl
@@ -9,5 +9,6 @@ layout(location = 0) rayPayloadInEXT RayPayload payload;
 
 void main() {
     payload.hit = false;
-    payload.color = vec4(0.95, 1.0, 1.0, 1.0);
+    payload.color = 0.05 * vec4(0.95, 1.0, 1.0, 1.0);
+    payload.emissive = true;
 }

--- a/shaders/rmiss.glsl
+++ b/shaders/rmiss.glsl
@@ -9,6 +9,6 @@ layout(location = 0) rayPayloadInEXT RayPayload payload;
 
 void main() {
     payload.hit = false;
-    payload.color = 0.05 * vec4(0.95, 1.0, 1.0, 1.0);
+    payload.color = 0.25 * vec4(0.95, 1.0, 1.0, 1.0);
     payload.emissive = true;
 }

--- a/shaders/tonemap_comp.glsl
+++ b/shaders/tonemap_comp.glsl
@@ -13,7 +13,7 @@ void main()
     // Just a clamp for the time being, 
     // but can be used for denoising + tonemapping in the future.
     ivec2 pixel = ivec2(gl_GlobalInvocationID.xy);
-    vec4 pixel_color = imageLoad(image_normals, pixel);
+    vec4 pixel_color = imageLoad(noisy_image, pixel);
     pixel_color = clamp(pixel_color, 0.0, 1.0);
     imageStore(output_image, pixel, pixel_color);
 }

--- a/shaders/tonemap_comp.glsl
+++ b/shaders/tonemap_comp.glsl
@@ -3,6 +3,8 @@
 
 layout (binding = 0, rgba8) uniform writeonly image2D output_image;
 layout (binding = 1, rgba8) uniform readonly image2D noisy_image;
+layout (binding = 2, rgba8) uniform readonly image2D image_normals;
+layout (binding = 3, rgba8) uniform readonly image2D image_positions;
 
 layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 
@@ -11,7 +13,7 @@ void main()
     // Just a clamp for the time being, 
     // but can be used for denoising + tonemapping in the future.
     ivec2 pixel = ivec2(gl_GlobalInvocationID.xy);
-    vec4 pixel_color = imageLoad(noisy_image, pixel);
+    vec4 pixel_color = imageLoad(image_normals, pixel);
     pixel_color = clamp(pixel_color, 0.0, 1.0);
     imageStore(output_image, pixel, pixel_color);
 }

--- a/shaders/tonemap_comp.glsl
+++ b/shaders/tonemap_comp.glsl
@@ -1,8 +1,8 @@
 #version 460
 #pragma shader_stage(compute)
 
-layout (binding = 0, rgba8) uniform readonly image2D preprocessed_image;
-layout (binding = 1, rgba8) uniform writeonly image2D output_image;
+layout (binding = 0, rgba8) uniform writeonly image2D output_image;
+layout (binding = 1, rgba8) uniform readonly image2D noisy_image;
 
 layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 
@@ -11,7 +11,7 @@ void main()
     // Just a clamp for the time being, 
     // but can be used for denoising + tonemapping in the future.
     ivec2 pixel = ivec2(gl_GlobalInvocationID.xy);
-    vec4 pixel_color = imageLoad(preprocessed_image, pixel);
+    vec4 pixel_color = imageLoad(noisy_image, pixel);
     pixel_color = clamp(pixel_color, 0.0, 1.0);
     imageStore(output_image, pixel, pixel_color);
 }

--- a/voxels/Voxel.h
+++ b/voxels/Voxel.h
@@ -33,6 +33,7 @@ class VoxelChunk {
     enum class AttributeSet {
         Color,
         ColorNormal,
+        Emissive,
     };
 
     VoxelChunk(std::vector<std::byte> &&data, uint32_t width, uint32_t height,
@@ -123,4 +124,5 @@ const static std::unordered_map<VoxelChunk::Format, std::string_view> format_nam
 const static std::unordered_map<VoxelChunk::AttributeSet, std::string_view> attribute_set_names {
     {VoxelChunk::AttributeSet::Color, "Color"},
     {VoxelChunk::AttributeSet::ColorNormal, "ColorNormal"},
+    {VoxelChunk::AttributeSet::Emissive, "Emissive"}
 };


### PR DESCRIPTION
Adds emissive voxels so that there are also voxel lights instead of only a sky light. Note that there is no direct light sampling happening yet, and all of the emissivity comes from indirect light samples. 

Also provides some additional information to the tonemapper in preparation for denoising (likely starting with the edge-avoiding A-trous filter).