### PR TITLE
Use Buffers instead of Images for Raw Data

### DIFF
--- a/drivers/benchmark_graphics.cpp
+++ b/drivers/benchmark_graphics.cpp
@@ -1,6 +1,7 @@
 #include <graphics/GraphicsContext.h>
 #include <voxels/Voxel.h>
 #include <voxels/VoxelChunkGeneration.h>
+#include <voxels/Conversion.h>
 
 int main(int argc, char *argv[]) {
     ChunkManager chunk_manager;
@@ -13,7 +14,7 @@ int main(int argc, char *argv[]) {
             static_cast<float>(i) / static_cast<float>(num_objects);
         const float radians = linear * 2.0F * 3.1415926;
         auto test_sphere_data =
-            generate_basic_sphere_chunk(64, 64, 64, 4.0F + 60.0F * linear);
+            append_metadata_to_raw(generate_basic_sphere_chunk(64, 64, 64, 4.0F + 60.0F * linear), 64, 64, 64);
         VoxelChunkPtr test_sphere = chunk_manager.add_chunk(
             std::move(test_sphere_data), 64, 64, 64, VoxelChunk::Format::Raw,
             VoxelChunk::AttributeSet::Color);

--- a/drivers/island.cpp
+++ b/drivers/island.cpp
@@ -215,7 +215,7 @@ int main(int argc, char *argv[]) {
     
 
     // Add emissive voxels
-    auto emissive_block = generate_basic_filled_chunk(8, 8, 8);
+    auto emissive_block = append_metadata_to_raw(generate_basic_filled_chunk(8, 8, 8), 8, 8, 8);
     VoxelChunkPtr test_light = chunk_manager.add_chunk(
         std::move(emissive_block), 8, 8, 8, VoxelChunk::Format::Raw,
         VoxelChunk::AttributeSet::Emissive);

--- a/drivers/ivs.cpp
+++ b/drivers/ivs.cpp
@@ -26,7 +26,7 @@ int main(int argc, char *argv[]) {
                               0.0F, -64.0F, 0.0F, 0.0F,   1.0F, -64.0F};
     auto object1 = build_object(context, model1, transform1);
 
-    auto emissive_block = generate_basic_filled_chunk(8, 8, 8);
+    auto emissive_block = append_metadata_to_raw(generate_basic_filled_chunk(8, 8, 8), 8, 8, 8);
     VoxelChunkPtr test_light = chunk_manager.add_chunk(
         std::move(emissive_block), 8, 8, 8, VoxelChunk::Format::Raw,
         VoxelChunk::AttributeSet::Emissive);

--- a/drivers/sponza.cpp
+++ b/drivers/sponza.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[]) {
     objects.emplace_back(std::move(sponza_object));
 
     // Add emissive voxels
-    auto emissive_block = generate_basic_filled_chunk(8, 8, 8);
+    auto emissive_block = append_metadata_to_raw(generate_basic_filled_chunk(8, 8, 8), 8, 8, 8);
     VoxelChunkPtr test_light = chunk_manager.add_chunk(
         std::move(emissive_block), 8, 8, 8, VoxelChunk::Format::Raw,
         VoxelChunk::AttributeSet::Emissive);

--- a/graphics/GraphicsContext.cpp
+++ b/graphics/GraphicsContext.cpp
@@ -165,15 +165,12 @@ GraphicsContext::GraphicsContext(std::shared_ptr<Window> window) {
     scene_builder.bind_acceleration_structure(0, {},
                                               VK_SHADER_STAGE_RAYGEN_BIT_KHR);
     scene_builder.bind_buffers(1, {}, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-                              VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
-                                  VK_SHADER_STAGE_INTERSECTION_BIT_KHR);
-    scene_builder.bind_buffers(2, {}, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
                                VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
                                    VK_SHADER_STAGE_INTERSECTION_BIT_KHR);
-    scene_builder.bind_buffer(3, {}, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+    scene_builder.bind_buffer(2, {}, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
 			      VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
 			      VK_SHADER_STAGE_INTERSECTION_BIT_KHR);
-    scene_builder.bind_buffer(4, {}, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+    scene_builder.bind_buffer(3, {}, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
                               VK_SHADER_STAGE_RAYGEN_BIT_KHR);
     
     chunk_request_buffer_ = std::make_shared<GPUBuffer>(
@@ -766,41 +763,37 @@ void GraphicsContext::bind_scene_descriptors(
         },
         VK_SHADER_STAGE_RAYGEN_BIT_KHR);
 
-    std::vector<std::pair<VkDescriptorBufferInfo, uint32_t>> raw_buffer_infos;
-    std::vector<std::pair<VkDescriptorBufferInfo, uint32_t>> sparse_buffer_infos;
+    std::vector<std::pair<VkDescriptorBufferInfo, uint32_t>> buffer_infos;
     for (size_t i = 0; i < models.size(); ++i) {
         const auto &model = models.at(i);
         if (model->chunk_->get_state() == VoxelChunk::State::GPU &&
             model->chunk_->get_format() == VoxelChunk::Format::Raw) {
             auto buffer = model->chunk_->get_gpu_buffer();
-            VkDescriptorBufferInfo raw_buffer_info{};
-            raw_buffer_info.buffer = buffer->get_buffer();
-            raw_buffer_info.offset = 0;
-            raw_buffer_info.range = buffer->get_size();
-            raw_buffer_infos.emplace_back(raw_buffer_info, i);
+            VkDescriptorBufferInfo buffer_info{};
+            buffer_info.buffer = buffer->get_buffer();
+            buffer_info.offset = 0;
+            buffer_info.range = buffer->get_size();
+            buffer_infos.emplace_back(buffer_info, i);
         } else if (model->chunk_->get_state() == VoxelChunk::State::GPU &&
                    (model->chunk_->get_format() == VoxelChunk::Format::SVO ||
 		    model->chunk_->get_format() == VoxelChunk::Format::SVDAG)) {
             auto buffer = model->chunk_->get_gpu_buffer();
-            VkDescriptorBufferInfo sparse_buffer_info{};
-            sparse_buffer_info.buffer = buffer->get_buffer();
-            sparse_buffer_info.offset = 0;
-            sparse_buffer_info.range = buffer->get_size();
-            sparse_buffer_infos.emplace_back(sparse_buffer_info, i);
+            VkDescriptorBufferInfo buffer_info{};
+            buffer_info.buffer = buffer->get_buffer();
+            buffer_info.offset = 0;
+            buffer_info.range = buffer->get_size();
+            buffer_infos.emplace_back(buffer_info, i);
         }
     }
-    builder.bind_buffers(1, raw_buffer_infos, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+    builder.bind_buffers(1, buffer_infos, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
                         VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
                             VK_SHADER_STAGE_INTERSECTION_BIT_KHR);
-    builder.bind_buffers(2, sparse_buffer_infos, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-                         VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
-                             VK_SHADER_STAGE_INTERSECTION_BIT_KHR);
 
     VkDescriptorBufferInfo chunk_dimensions_info{};
     chunk_dimensions_info.buffer = scene->chunk_dimensions_->get_buffer();
     chunk_dimensions_info.offset = 0;
     chunk_dimensions_info.range = scene->chunk_dimensions_->get_size();
-    builder.bind_buffer(3, chunk_dimensions_info, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+    builder.bind_buffer(2, chunk_dimensions_info, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
 			VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
 			VK_SHADER_STAGE_INTERSECTION_BIT_KHR);
 
@@ -808,7 +801,7 @@ void GraphicsContext::bind_scene_descriptors(
     emissive_voxels_info.buffer = scene->emissive_voxels_->get_buffer();
     emissive_voxels_info.offset = 0;
     emissive_voxels_info.range = scene->emissive_voxels_->get_size();
-    builder.bind_buffer(4, emissive_voxels_info,
+    builder.bind_buffer(3, emissive_voxels_info,
                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
                         VK_SHADER_STAGE_RAYGEN_BIT_KHR);
 }

--- a/graphics/GraphicsContext.cpp
+++ b/graphics/GraphicsContext.cpp
@@ -766,17 +766,7 @@ void GraphicsContext::bind_scene_descriptors(
     std::vector<std::pair<VkDescriptorBufferInfo, uint32_t>> buffer_infos;
     for (size_t i = 0; i < models.size(); ++i) {
         const auto &model = models.at(i);
-        if (model->chunk_->get_state() == VoxelChunk::State::GPU &&
-            model->chunk_->get_format() == VoxelChunk::Format::Raw) {
-            auto buffer = model->chunk_->get_gpu_buffer();
-            VkDescriptorBufferInfo buffer_info{};
-            buffer_info.buffer = buffer->get_buffer();
-            buffer_info.offset = 0;
-            buffer_info.range = buffer->get_size();
-            buffer_infos.emplace_back(buffer_info, i);
-        } else if (model->chunk_->get_state() == VoxelChunk::State::GPU &&
-                   (model->chunk_->get_format() == VoxelChunk::Format::SVO ||
-		    model->chunk_->get_format() == VoxelChunk::Format::SVDAG)) {
+        if (model->chunk_->get_state() == VoxelChunk::State::GPU) {
             auto buffer = model->chunk_->get_gpu_buffer();
             VkDescriptorBufferInfo buffer_info{};
             buffer_info.buffer = buffer->get_buffer();

--- a/shaders/Emissive_rchit.glsl
+++ b/shaders/Emissive_rchit.glsl
@@ -16,13 +16,21 @@ void main() {
 
     vec3 voxel_sample_pos = gl_WorldToObjectEXT * vec4(world_ray_pos, 1.0);
     ivec3 volume_load_pos = ivec3(voxel_sample_pos - 0.5 * voxel_normals[gl_HitKindEXT]);
+    uint voxel_index = linearize_index(volume_load_pos, raw_buffers[volume_id].voxel_width, raw_buffers[volume_id].voxel_height, raw_buffers[volume_id].voxel_depth); 
 
     payload.hit = true;
     payload.world_position = world_ray_pos;
     payload.world_normal = gl_ObjectToWorldEXT * vec4(voxel_normals[gl_HitKindEXT], 0.0);
     payload.tangent = gl_ObjectToWorldEXT * vec4(voxel_tangents[gl_HitKindEXT], 0.0);
     payload.bitangent = gl_ObjectToWorldEXT * vec4(voxel_bitangents[gl_HitKindEXT], 0.0);
-    payload.color = imageLoad(volumes[volume_id], volume_load_pos);
+    
+    RawColor color = raw_buffers[volume_id].voxel_colors[voxel_index];
+    payload.color = vec4(
+	       float(int(color.red_)) / 255.0,
+	       float(int(color.green_)) / 255.0,
+	       float(int(color.blue_)) / 255.0,
+	       float(int(color.alpha_)) / 255.0
+	       );
     payload.voxel_face = gl_HitKindEXT;
     payload.emissive = true;
 }

--- a/shaders/Raw_Color_rchit.glsl
+++ b/shaders/Raw_Color_rchit.glsl
@@ -16,13 +16,21 @@ void main() {
 
     vec3 voxel_sample_pos = gl_WorldToObjectEXT * vec4(world_ray_pos, 1.0);
     ivec3 volume_load_pos = ivec3(voxel_sample_pos - 0.5 * voxel_normals[gl_HitKindEXT]);
+    uint voxel_index = linearize_index(volume_load_pos, raw_buffers[volume_id].voxel_width, raw_buffers[volume_id].voxel_height, raw_buffers[volume_id].voxel_depth); 
 
     payload.hit = true;
     payload.world_position = world_ray_pos;
     payload.world_normal = normalize(gl_ObjectToWorldEXT * vec4(voxel_normals[gl_HitKindEXT], 0.0));
     payload.tangent = normalize(gl_ObjectToWorldEXT * vec4(voxel_tangents[gl_HitKindEXT], 0.0));
     payload.bitangent = normalize(gl_ObjectToWorldEXT * vec4(voxel_bitangents[gl_HitKindEXT], 0.0));
-    payload.color = imageLoad(volumes[volume_id], volume_load_pos);
+    
+    RawColor color = raw_buffers[volume_id].voxel_colors[voxel_index];
+    payload.color = vec4(
+	       float(int(color.red_)) / 255.0,
+	       float(int(color.green_)) / 255.0,
+	       float(int(color.blue_)) / 255.0,
+	       float(int(color.alpha_)) / 255.0
+	       );
     payload.voxel_face = gl_HitKindEXT;
     payload.emissive = false;
 }

--- a/shaders/Raw_Color_rint.glsl
+++ b/shaders/Raw_Color_rint.glsl
@@ -11,7 +11,7 @@ void main() {
     vec3 obj_ray_pos = gl_WorldToObjectEXT * vec4(gl_WorldRayOriginEXT, 1.0);
     vec3 obj_ray_dir = normalize(gl_WorldToObjectEXT * vec4(gl_WorldRayDirectionEXT, 0.0));
 
-    ivec3 volume_size = imageSize(volumes[volume_id]);
+    ivec3 volume_size = ivec3(raw_buffers[volume_id].voxel_width, raw_buffers[volume_id].voxel_height, raw_buffers[volume_id].voxel_depth);
     aabb_intersect_result r = hit_aabb(vec3(0.0), volume_size, obj_ray_pos, obj_ray_dir);
 
     if (r.front_t != -FAR_AWAY) {
@@ -24,7 +24,8 @@ void main() {
 	uint steps = 0;
 	uint max_steps = uint(volume_size.x) + uint(volume_size.y) + uint(volume_size.z);
 	while (steps < max_steps && all(greaterThanEqual(obj_ray_voxel, ivec3(0))) && all(lessThan(obj_ray_voxel, volume_size))) {
-	    float palette = imageLoad(volumes[volume_id], obj_ray_voxel).a;
+		uint32_t voxel_index = linearize_index(obj_ray_voxel, volume_size.x, volume_size.y, volume_size.z);
+	    float palette = float(raw_buffers[volume_id].voxel_colors[voxel_index].alpha_);
 	    
 	    if (palette != 0.0) {
 		aabb_intersect_result r = hit_aabb(obj_ray_voxel, obj_ray_voxel + 1, obj_ray_pos, obj_ray_dir);

--- a/shaders/common.glsl
+++ b/shaders/common.glsl
@@ -73,7 +73,7 @@ layout(set = 1, binding = 1) buffer RawBuffer {
     RawColor voxel_colors[];
 } raw_buffers[];
 
-layout(set = 1, binding = 2) buffer SVOBuffer {
+layout(set = 1, binding = 1) buffer SVOBuffer {
     uint32_t voxel_width;
     uint32_t voxel_height;
     uint32_t voxel_depth;
@@ -81,7 +81,7 @@ layout(set = 1, binding = 2) buffer SVOBuffer {
     SVONode nodes[];
 } svo_buffers[];
 
-layout(set = 1, binding = 2) buffer SVOBuffer_Color {
+layout(set = 1, binding = 1) buffer SVOBuffer_Color {
     uint32_t voxel_width;
     uint32_t voxel_height;
     uint32_t voxel_depth;
@@ -89,7 +89,7 @@ layout(set = 1, binding = 2) buffer SVOBuffer_Color {
     SVOLeaf_Color nodes[];
 } svo_leaf_color_buffers[];
 
-layout(set = 1, binding = 2) buffer SVDAGBuffer {
+layout(set = 1, binding = 1) buffer SVDAGBuffer {
     uint32_t voxel_width;
     uint32_t voxel_height;
     uint32_t voxel_depth;
@@ -97,7 +97,7 @@ layout(set = 1, binding = 2) buffer SVDAGBuffer {
     SVDAGNode nodes[];
 } svdag_buffers[];
 
-layout(set = 1, binding = 2) buffer SVDAGBuffer_Color {
+layout(set = 1, binding = 1) buffer SVDAGBuffer_Color {
     uint32_t voxel_width;
     uint32_t voxel_height;
     uint32_t voxel_depth;
@@ -105,11 +105,11 @@ layout(set = 1, binding = 2) buffer SVDAGBuffer_Color {
     SVDAGLeaf_Color nodes[];
 } svdag_leaf_color_buffers[];
 
-layout(set = 1, binding = 3) buffer chunk_dimensions_ {
+layout(set = 1, binding = 2) buffer chunk_dimensions_ {
     uint32_t chunk_dimensions[MAX_MODELS * 3];
 };
 
-layout(set = 1, binding = 4) buffer direct_lights_ {
+layout(set = 1, binding = 3) buffer direct_lights_ {
     uint32_t num_emissive_voxels;
 
     // Each voxel uses 6 values

--- a/shaders/common.glsl
+++ b/shaders/common.glsl
@@ -8,6 +8,13 @@
 #define MAX_MODELS (2 << 16)
 #define MAX_NUM_CHUNKS_LOADED_PER_FRAME 32
 
+struct RawColor {
+    uint8_t red_;
+    uint8_t green_;
+    uint8_t blue_;
+    uint8_t alpha_;
+};
+
 struct SVONode {
     uint32_t child_offset_;
     uint8_t valid_mask_;
@@ -59,7 +66,12 @@ layout(set = 0, binding = 0, rgba8) uniform image2D output_image;
 // Set 1 is swapped out per scene.
 layout(set = 1, binding = 0) uniform accelerationStructureEXT tlas;
 
-layout(set = 1, binding = 1, rgba8) uniform readonly image3D volumes[];
+layout(set = 1, binding = 1) buffer RawBuffer {
+    uint32_t voxel_width;
+    uint32_t voxel_height;
+    uint32_t voxel_depth;
+    RawColor voxel_colors[];
+} raw_buffers[];
 
 layout(set = 1, binding = 2) buffer SVOBuffer {
     uint32_t voxel_width;
@@ -158,4 +170,8 @@ aabb_intersect_result hit_aabb(const vec3 minimum, const vec3 maximum, const vec
 	r.k = tbot.z > ttop.z ? 5 : 4;
     }
     return r;
+}
+
+uint32_t linearize_index(ivec3 index, uint32_t width, uint32_t height, uint32_t depth) {
+    return uint32_t(index.x + width * index.y + width * height * index.z);
 }

--- a/voxels/Conversion.cpp
+++ b/voxels/Conversion.cpp
@@ -5,6 +5,40 @@
 #include "Conversion.h"
 #include "utils/Assert.h"
 
+struct RawColor {
+    uint8_t red_;
+    uint8_t green_;
+    uint8_t blue_;
+    uint8_t alpha_;
+};
+
+std::vector<std::byte> append_metadata_to_raw(const std::vector<std::byte>& raw,
+    uint32_t width, uint32_t height,
+    uint32_t depth) {
+    std::vector<std::byte> raw_data;
+    for (int i = 0; i < 3 * sizeof(uint32_t); i++) {
+        raw_data.emplace_back();
+    }
+
+    memcpy(&raw_data.at(0), &width, sizeof(uint32_t));
+    memcpy(&raw_data.at(sizeof(uint32_t)), &height, sizeof(uint32_t));
+    memcpy(&raw_data.at(sizeof(uint32_t) * 2), &depth, sizeof(uint32_t));
+    for (uint32_t i = 0; i < raw.size(); i += 4) {
+        RawColor voxel = {.red_ = static_cast<uint8_t>(raw.at(i)),
+                          .green_ = static_cast<uint8_t>(raw.at(i + 1)),
+                          .blue_ = static_cast<uint8_t>(raw.at(i + 2)),
+                          .alpha_ = static_cast<uint8_t>(raw.at(i + 3))};
+
+        for (uint32_t i = 0; i < sizeof(RawColor); ++i) {
+            raw_data.emplace_back();
+        }
+
+        memcpy(&raw_data.back() - sizeof(RawColor) + 1, &voxel, sizeof(RawColor));
+    }
+    // memcpy(&raw_data.at(sizeof(uint32_t) * 3), raw.data(), raw.size());
+    return raw_data;
+}
+
 struct SVONode {
     uint32_t child_offset_;
     uint32_t valid_mask_ : 8;

--- a/voxels/Conversion.h
+++ b/voxels/Conversion.h
@@ -2,6 +2,10 @@
 
 #include "Voxel.h"
 
+std::vector<std::byte> append_metadata_to_raw(const std::vector<std::byte> &raw,
+                                              uint32_t width, uint32_t height,
+                                              uint32_t depth);
+
 std::vector<std::byte> convert_raw_to_svo(const std::vector<std::byte> &raw,
                                           uint32_t width, uint32_t height,
                                           uint32_t depth,

--- a/voxels/Voxel.h
+++ b/voxels/Voxel.h
@@ -43,7 +43,6 @@ class VoxelChunk {
 
     std::span<const std::byte> get_cpu_data() const;
     std::shared_ptr<GPUBuffer> get_gpu_buffer() const;
-    std::shared_ptr<GPUVolume> get_gpu_volume() const;
     std::shared_ptr<Semaphore> get_timeline() const;
     uint32_t get_width() const;
     uint32_t get_height() const;
@@ -65,7 +64,6 @@ class VoxelChunk {
     std::filesystem::path disk_path_;
     std::vector<std::byte> cpu_data_;
     std::shared_ptr<GPUBuffer> buffer_data_;
-    std::shared_ptr<GPUVolume> volume_data_;
     std::shared_ptr<Semaphore> timeline_ = nullptr;
     uint32_t width_;
     uint32_t height_;


### PR DESCRIPTION
Converts the raw data storage from image volumes to buffers. Overall changes include modifying the shaders to read from buffers instead of images, and adding metadata to describe dimensions.